### PR TITLE
Moved rod constrain changes over from simcore branch

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -132,6 +132,9 @@ rigid_filament:
   max_length: [500, double]          # maximum filament length. also used for dynamic instability.
   min_length: [5, double]            # minimum filament length. also used for dynamic instability.
   stationary_flag: [false, bool]     # If true, rigid_filaments will not move regardless of forces on them.
+  constrain_motion_flag: [false, bool] # If true, rigid filaments will move in planes such that two filaments
+                                       # will never physically overlap if they do not begin overlapping.
+                                       # This only works for two filaments. Warning will be thrown otherwise.
   packing_fraction: [-1, double]    # if num > 0, and packing fraction > 0, filaments are inserted
   #                                  # until the ratio filament to system volumes match this value.
   n_equil: [0, int]                 # internal filament parameter used for shuffling.

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -15,6 +15,7 @@
   default_config["rigid_filament"]["max_length"] = "500";
   default_config["rigid_filament"]["min_length"] = "5";
   default_config["rigid_filament"]["stationary_flag"] = "false";
+  default_config["rigid_filament"]["constrain_motion_flag"] = "false";
   default_config["rigid_filament"]["packing_fraction"] = "-1";
   default_config["rigid_filament"]["n_equil"] = "0";
   default_config["filament"]["packing_fraction"] = "-1";

--- a/include/cglass/minimum_distance.hpp
+++ b/include/cglass/minimum_distance.hpp
@@ -11,8 +11,8 @@ private:
   static double *unit_cell_;
   static double boundary_cut2_;
   static space_struct *space_;
-public:
 
+public:
   void PointPoint(double const *const r1, double const *const s1,
                   double const *const r2, double const *const s2, double *dr,
                   double *dr_mag2, double *midpoint);
@@ -38,9 +38,10 @@ public:
   void SpheroPlane(double *r_bond, double *u_bond, double length,
                    double *r_plane, double *n_plane, double *lambda,
                    double *r_min_mag2, double *r_min);
-  void CarrierLines(double *r_1, double *s_1, double *u_1, double *r_2,
-                    double *s_2, double *u_2, double *r_min, double *r_min_mag2,
-                    double *lambda, double *mu);
+  void CarrierLines(const double *r_1, const double *s_1, const double *u_1,
+                    const double *r_2, const double *s_2, const double *u_2,
+                    double *r_min, double *r_min_mag2, double *lambda,
+                    double *mu);
   void PointSphereBC(double const *const r, double *dr, double *dr_mag2,
                      double buffer);
   void SpheroSphereBC(double const *const r, double const *const u,

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -30,6 +30,7 @@ struct species_parameters<species_id::rigid_filament>
   double max_length = 500;
   double min_length = 5;
   bool stationary_flag = false;
+  bool constrain_motion_flag = false;
   double packing_fraction = -1;
   int n_equil = 0;
 };

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -254,6 +254,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.min_length = jt->second.as<double>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("constrain_motion_flag")==0) {
+      params.constrain_motion_flag = jt->second.as<bool>();
       } else if (param_name.compare("packing_fraction")==0) {
       params.packing_fraction = jt->second.as<double>();
       } else if (param_name.compare("n_equil")==0) {

--- a/include/cglass/rigid_filament.hpp
+++ b/include/cglass/rigid_filament.hpp
@@ -6,7 +6,7 @@
 #include "mesh.hpp"
 
 class RigidFilament : public Mesh {
- private:
+private:
   rigid_filament_parameters *sparams_;
   double gamma_par_ = 0;
   double gamma_perp_ = 0;
@@ -17,12 +17,13 @@ class RigidFilament : public Mesh {
   double body_frame_[6];
   double min_length_ = 0;
   double max_length_ = 1000;
+  double constrain_vec_[3] = {}; // Rigid filaments move only in plane defined
+                                 // by this unit vector.
 
   bool zero_temperature_ = false;
   int n_step_ = 0;
   int eq_steps_ = 0;
   int eq_steps_count_ = 0;
-
 
   void UpdateSiteBondPositions();
   void SetDiffusion();
@@ -44,13 +45,13 @@ class RigidFilament : public Mesh {
 
   void CalculateBinding();
 
- protected:
+protected:
   void InsertRigidFilament(std::string insertion_type, double buffer = -1);
   void GetBodyFrame();
   void AddRandomDisplacement();
   void AddRandomReorientation();
 
- public:
+public:
   RigidFilament(unsigned long seed);
   virtual void Init(rigid_filament_parameters *sparams);
   virtual void InsertAt(const double *const new_pos, const double *const u);
@@ -67,6 +68,9 @@ class RigidFilament : public Mesh {
   double const *const GetHeadPosition() {
     return sites_[n_sites_ - 1].GetPosition();
   }
+  void SetConstrainVec(const double *constrain_vec) {
+    std::copy(constrain_vec, constrain_vec + 3, constrain_vec_);
+  }
   void WritePosit(std::fstream &oposit);
   void ReadPosit(std::fstream &iposit);
   void WriteSpec(std::fstream &ospec);
@@ -82,4 +86,4 @@ typedef std::vector<std::pair<std::vector<RigidFilament>::iterator,
                               std::vector<RigidFilament>::iterator>>
     rigid_filament_chunk_vector;
 
-#endif  // _CGLASS_RIGID_FILAMENT_H_
+#endif // _CGLASS_RIGID_FILAMENT_H_

--- a/include/cglass/rigid_filament_species.hpp
+++ b/include/cglass/rigid_filament_species.hpp
@@ -1,15 +1,17 @@
 #ifndef _CGLASS_RIGID_FILAMENT_SPECIES_H_
 #define _CGLASS_RIGID_FILAMENT_SPECIES_H_
 
+#include "minimum_distance.hpp"
 #include "rigid_filament.hpp"
 #include "species.hpp"
 
 class RigidFilamentSpecies
     : public Species<RigidFilament, species_id::rigid_filament> {
- protected:
+protected:
   double fill_volume_;
   double packing_fraction_;
- public:
+
+public:
   RigidFilamentSpecies(unsigned long seed);
   void Init(std::string spec_name, ParamsParser &parser);
   void PopMember();
@@ -18,6 +20,7 @@ class RigidFilamentSpecies
 
   void Reserve();
   void UpdatePositions();
+  void CustomInsert();
   // Redundant for filaments.
   virtual void CenteredOrientedArrangement() {}
 };

--- a/src/minimum_distance.cpp
+++ b/src/minimum_distance.cpp
@@ -610,8 +610,9 @@ output: minimimum separation vector (r_min)
 (lambda) pointer to intersection of r_min with axis of second spherocylinder
 (mu). */
 
-void MinimumDistance::CarrierLines(double *r_1, double *s_1, double *u_1,
-                                   double *r_2, double *s_2, double *u_2,
+void MinimumDistance::CarrierLines(const double *r_1, const double *s_1,
+                                   const double *u_1, const double *r_2,
+                                   const double *s_2, const double *u_2,
                                    double *r_min, double *r_min_mag2,
                                    double *lambda, double *mu) {
   int i, j;

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -13,7 +13,7 @@ void RigidFilament::SetParameters() {
   diameter_ = sparams_->diameter;
   max_length_ = sparams_->max_length;
   min_length_ = sparams_->min_length;
-  zero_temperature_ = params_->zero_temperature;  // include thermal forces
+  zero_temperature_ = params_->zero_temperature; // include thermal forces
   eq_steps_count_ = 0;
 
   /* Refine parameters */
@@ -26,7 +26,6 @@ void RigidFilament::Init(rigid_filament_parameters *sparams) {
   Reserve();
   InsertRigidFilament(sparams_->insertion_type, -1);
   SetDiffusion();
-
 }
 
 /* Returns number of bonds to initialize */
@@ -99,8 +98,24 @@ void RigidFilament::InsertRigidFilament(std::string insertion_type,
    relative to rod. */
 void RigidFilament::Integrate() {
   // Explicit calculation of Xi.F_s
-  double fric_mat[9] = {};  // Friction matrix for filament
-  double mob_mat[9] = {};   // Mobility matrix for filament
+  double fric_mat[9] = {}; // Friction matrix for filament
+  double mob_mat[9] = {};  // Mobility matrix for filament
+  double force_eff[3];
+  double torque_eff[3];
+  std::copy(force_, force_ + 3, force_eff);
+  std::copy(torque_, torque_ + 3, torque_eff);
+
+  // Constrain the motion of filaments to a plane defined by constrain_vec_
+  // by subtracting force components out of the plane and keeping torque
+  // components only along constrain_vec_ direction.
+  if (sparams_->constrain_motion_flag) {
+    double f_dot_u = dot_product(3, force_, constrain_vec_);
+    double t_dot_u = dot_product(3, torque_, constrain_vec_);
+    for (int i = 0; i < 3; ++i) {
+      force_eff[i] -= f_dot_u * constrain_vec_[i];
+      torque_eff[i] = t_dot_u * constrain_vec_[i];
+    }
+  }
   // Construct mobility matrix
   for (int i = 0; i < n_dim_; ++i) {
     for (int j = i + 1; j < n_dim_; ++j) {
@@ -116,15 +131,16 @@ void RigidFilament::Integrate() {
 
   for (int i = 0; i < n_dim_; ++i) {
     for (int j = 0; j < n_dim_; ++j) {
-      position_[i] += mob_mat[i * n_dim_ + j] * force_[j] * delta_;
+      position_[i] += mob_mat[i * n_dim_ + j] * force_eff[j] * delta_;
     }
   }
   // Reorientation due to external torques
   double du[3];
-  cross_product(torque_, orientation_, du, 3);  // ndim=3 since torques
+  cross_product(torque_eff, orientation_, du, 3); // ndim=3 since torques
   for (int i = 0; i < n_dim_; ++i) {
     orientation_[i] += du[i] * delta_ / gamma_rot_;
   }
+  normalize_vector(orientation_, n_dim_);
   if (!zero_temperature_) {
     // Add the random displacement dr(t)
     AddRandomDisplacement();
@@ -149,7 +165,8 @@ void RigidFilament::AddRandomDisplacement() {
   GetBodyFrame();
   // First handle the parallel component
   double mag = rng_.RandomNormal(diffusion_par_);
-  for (int i = 0; i < n_dim_; ++i) position_[i] += mag * orientation_[i];
+  for (int i = 0; i < n_dim_; ++i)
+    position_[i] += mag * orientation_[i];
   // Then the perpendicular component(s)
   for (int j = 0; j < n_dim_ - 1; ++j) {
     mag = rng_.RandomNormal(diffusion_perp_);
@@ -229,7 +246,8 @@ double const RigidFilament::GetVolume() {
 
 void RigidFilament::UpdatePosition() {
   ApplyForcesTorques();
-  if (!sparams_->stationary_flag) Integrate();
+  if (!sparams_->stationary_flag)
+    Integrate();
   eq_steps_count_++;
 }
 
@@ -302,7 +320,8 @@ void RigidFilament::ApplyInteractionForces() {
     // Add translational forces and pure torque forces at bond ends
     sites_[i].AddForce(site_force);
     sites_[i].AddForce(pure_torque);
-    for (int j = 0; j < n_dim_; ++j) pure_torque[j] *= -1;
+    for (int j = 0; j < n_dim_; ++j)
+      pure_torque[j] *= -1;
     sites_[i + 1].AddForce(site_force);
     sites_[i + 1].AddForce(pure_torque);
   }
@@ -338,8 +357,7 @@ void RigidFilament::ScalePosition() {
   UpdateBondPositions();
 }
 
-void RigidFilament::ReportAll() {
-}
+void RigidFilament::ReportAll() {}
 
 void RigidFilament::WriteSpec(std::fstream &ospec) {
   Logger::Trace("Writing rigid filament specs, object id: %d", GetOID());
@@ -347,7 +365,8 @@ void RigidFilament::WriteSpec(std::fstream &ospec) {
 }
 
 void RigidFilament::ReadSpec(std::fstream &ispec) {
-  if (ispec.eof()) return;
+  if (ispec.eof())
+    return;
   Mesh::ReadSpec(ispec);
 }
 
@@ -378,7 +397,8 @@ void RigidFilament::WritePosit(std::fstream &oposit) {
    double length
 */
 void RigidFilament::ReadPosit(std::fstream &iposit) {
-  if (iposit.eof()) return;
+  if (iposit.eof())
+    return;
   posits_only_ = true;
   for (int i = 0; i < 3; ++i)
     iposit.read(reinterpret_cast<char *>(&position_[i]), sizeof(double));

--- a/src/rigid_filament_species.cpp
+++ b/src/rigid_filament_species.cpp
@@ -9,11 +9,10 @@ void RigidFilamentSpecies::Init(std::string spec_name, ParamsParser &parser) {
   packing_fraction_ = sparams_.packing_fraction;
 #ifdef TRACE
   if (packing_fraction_ > 0) {
-    Logger::Warning(
-        "Simulation run in trace mode with a potentially large "
-        "number of objects in species %s (packing fraction ="
-        " %2.4f)",
-        GetSID()._to_string(), packing_fraction_);
+    Logger::Warning("Simulation run in trace mode with a potentially large "
+                    "number of objects in species %s (packing fraction ="
+                    " %2.4f)",
+                    GetSID()._to_string(), packing_fraction_);
     fprintf(stderr, "Continue anyway? (y/N) ");
     char c;
     if (std::cin.peek() != 'y') {
@@ -36,6 +35,60 @@ void RigidFilamentSpecies::Init(std::string spec_name, ParamsParser &parser) {
   //      sparams_.length, min_length, min_length);
   //  sparams_.length = min_length;
   //}
+}
+
+void RigidFilamentSpecies::CustomInsert() {
+  Species::CustomInsert();
+  if (sparams_.constrain_motion_flag) {
+    if (n_members_ == 2) {
+
+      // Variables to store
+      double r_min[3], lambda, mu;
+      double dr[3] = {};
+      double n_dim = params_->n_dim;
+      // Find min distance unit vector between carrier lines to use as
+      // constraining vector
+      const double *r_1 = members_[0].GetPosition();
+      const double *u_1 = members_[0].GetOrientation();
+      const double *r_2 = members_[1].GetPosition();
+      const double *u_2 = members_[1].GetOrientation();
+      for (int i = 0; i < n_dim; ++i) {
+        dr[i] = r_2[i] - r_1[i];
+      }
+      double dr_dot_u_1 = dot_product(n_dim, dr, u_1);
+      double dr_dot_u_2 = dot_product(n_dim, dr, u_2);
+      double u_1_dot_u_2 = dot_product(n_dim, u_1, u_2);
+      double denom = 1.0 - SQR(u_1_dot_u_2);
+      if (denom < 1.0e-12) {
+        lambda = dr_dot_u_1 / 2.0;
+        mu = -dr_dot_u_2 / 2.0;
+      } else {
+        lambda = (dr_dot_u_1 - u_1_dot_u_2 * dr_dot_u_2) / denom;
+        mu = (-dr_dot_u_2 + u_1_dot_u_2 * dr_dot_u_1) / denom;
+      }
+
+      /* Calculate minimum distance between two lines. */
+      double r_min_mag2 = 0.0;
+      for (int i = 0; i < n_dim; ++i) {
+        r_min[i] = dr[i] - lambda * u_1[i] + mu * u_2[i];
+        r_min_mag2 += SQR(r_min[i]);
+      }
+
+      normalize_vector(r_min, n_dim);
+      Logger::Info("Constraining motion of rigid rods to plane with vector = "
+                   "%f, %f, %f \n",
+                   r_min[0], r_min[1], r_min[2]);
+      //" << std::endl;
+      // printf("r_min_vec = %f, %f, %f \n", r_min[0], r_min[1], r_min[2]);
+
+      members_[0].SetConstrainVec(r_min);
+      members_[1].SetConstrainVec(r_min);
+    } else {
+      Logger::Warning("Cannot constrain motion of more than two filaments. "
+                      "Constraint not applied!");
+      sparams_.constrain_motion_flag = false;
+    }
+  }
 }
 
 void RigidFilamentSpecies::UpdatePositions() {
@@ -109,626 +162,3 @@ void RigidFilamentSpecies::PopMember() {
   Species::PopMember();
 }
 
-// const double RigidFilamentSpecies::GetSpecLength() const {
-//  if (sparams_.dynamic_instability_flag) {
-//    return 2 * sparams_.min_bond_length;
-//  } else {
-//    return 1.5 * sparams_.min_bond_length;
-//  }
-//}
-// void RigidFilamentSpecies::InitAnalysis() {
-//  time_ = 0;
-//  if (sparams_.spiral_flag) {
-//    InitSpiralAnalysis();
-//  }
-//  if (sparams_.theta_analysis) {
-//    if (params_->interaction_flag) {
-//      Logger::Warning("Theta analysis running on interacting filaments!");
-//    }
-//    InitThetaAnalysis();
-//  }
-//  // if (sparams_.crossing_analysis) {
-//  if (sparams_.crossing_analysis) {
-//    InitCrossingAnalysis();
-//  }
-//  if (sparams_.lp_analysis) {
-//    InitMse2eAnalysis();
-//  }
-//  if (sparams_.global_order_analysis) {
-//    InitGlobalOrderAnalysis();
-//  }
-//  if (params_->polar_order_analysis) {
-//    InitPolarOrderAnalysis();
-//  }
-//  if (sparams_.orientation_corr_analysis) {
-//    InitOrientationCorrelationAnalysis();
-//  }
-//  if (sparams_.flocking_analysis) {
-//    if (!params_->polar_order_analysis) {
-//      Logger::Error(
-//          "Flocking analysis requires polar order analysis to be "
-//          "enabled");
-//    }
-//    InitFlockingAnalysis();
-//  }
-//  RunAnalysis();
-//  if (params_->in_out_flag) {
-//    std::string fname = params_->run_name;
-//    fname.append("_filament.in_out");
-//    in_out_file_.open(fname, std::ios::out);
-//    in_out_file_ << "perlen: " << sparams_.perlen_ratio << "\n";
-//    in_out_file_ << "umax: " << params_->soft_potential_mag << "\n";
-//    in_out_file_ << "angle_in: ";
-//    if (members_.size() < 2) {
-//      Logger::Error(
-//          "Error in in-out analysis in RigidFilamentSpecies::InitAnalysis");
-//    }
-//    double u1[3] = {0, 0, 0};
-//    double u2[3] = {0, 0, 0};
-//    members_[0].GetAvgOrientation(u1);
-//    members_[1].GetAvgOrientation(u2);
-//    double dp = dot_product(params_->n_dim, u1, u2);
-//    in_out_file_ << acos(dp) << "\n";
-//  }
-//}
-
-// void RigidFilamentSpecies::InitGlobalOrderAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.global_order");
-//  global_order_file_.open(fname, std::ios::out);
-//  global_order_file_ << "global_order_analysis_file\n";
-//  global_order_file_
-//      << "time polar_order_x polar_order_y polar_order_z nematic_order_xx "
-//         "nematic_order_xy nematic_order_xz nematic_order_yx nematic_order_yy
-//         " "nematic_order_yz nematic_order_zx nematic_order_zy
-//         nematic_order_zz " "spiral_order signed_spiral_order n_spooling "
-//         "avg_spool_spiral_number\n";
-//  nematic_order_tensor_ = new double[9];
-//  polar_order_vector_ = new double[3];
-//  std::fill(nematic_order_tensor_, nematic_order_tensor_ + 9, 0.0);
-//  std::fill(polar_order_vector_, polar_order_vector_ + 3, 0.0);
-//}
-
-// void RigidFilamentSpecies::InitPolarOrderAnalysis() {
-//  n_bins_1d_ = params_->polar_order_n_bins;
-//  // Ensure n_bins_1d_ is even, to avoid headaches
-//  if (n_bins_1d_ % 2 != 0) {
-//    n_bins_1d_++;
-//  }
-//  n_bins_ = SQR(n_bins_1d_);
-//  polar_order_histogram_ = new int[n_bins_];
-//  std::fill(polar_order_histogram_, polar_order_histogram_ + n_bins_, 0.0);
-//  contact_cut_ = params_->polar_order_contact_cutoff;
-//  contact_bin_width_ = contact_cut_ / n_bins_1d_;
-//  polar_bin_width_ = 2.0 / n_bins_1d_;
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.polar_order");
-//  polar_order_file_.open(fname, std::ios::out);
-//  fname = params_->run_name;
-//  fname.append("_filament.polar_order_avg");
-//  polar_order_avg_file_.open(fname, std::ios::out);
-//  polar_order_avg_file_ << "polar_order_avg_file\n";
-//  polar_order_file_ << "contact_number local_polar_order\n";
-//  polar_order_avg_file_ << "time avg_polar_order avg_contact_number\n";
-//}
-
-// void RigidFilamentSpecies::RunPolarOrderAnalysis() {
-//  std::vector<double> po;
-//  std::vector<double> cn;
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    it->GetPolarOrders(&po);
-//    it->GetContactNumbers(&cn);
-//  }
-//  if (po.size() != cn.size()) {
-//    Logger::Error(
-//        "Number of polar order parameters and contact numbers not equal");
-//  }
-//  po_avg_ = 0;
-//  cn_avg_ = 0;
-//  for (int i = 0; i < po.size(); ++i) {
-//    po_avg_ += po[i];
-//    cn_avg_ += cn[i];
-//    if (cn[i] > contact_cut_) {
-//      continue;
-//    }
-//    // polar_order_file_ << cn[i] << " " << po[i] <<"\n";
-//    int x = (int)(floor(cn[i] / contact_bin_width_));
-//    int y = (int)(floor((po[i] + 1) / polar_bin_width_));
-//    if (y == n_bins_1d_) y = n_bins_1d_ - 1;
-//    if (x == n_bins_1d_) x = n_bins_1d_ - 1;
-//    if (y == -1) y = 0;
-//    if (x == -1) x = 0;
-//    if (y < 0 || x < 0 || y > n_bins_1d_ - 1 || x > n_bins_1d_ - 1) {
-//      std::cout << cn[i] << " " << po[i] << "\n";
-//      Logger::Error("Out of range in RunPolarOrderAnalysis");
-//    }
-//    polar_order_histogram_[n_bins_1d_ * y + x]++;
-//  }
-//  po_avg_ /= po.size();
-//  cn_avg_ /= cn.size();
-//  polar_order_avg_file_ << time_ << " " << po_avg_ << " " << cn_avg_ << "\n";
-//}
-
-// void RigidFilamentSpecies::InitOrientationCorrelationAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.orientation_corr");
-//  orientation_corr_file_.open(fname, std::ios::out);
-//  orientation_corr_n_steps_ = sparams_.orientation_corr_n_steps;
-//  orientation_corr_file_ << "orientation_corr_analysis_file, n_filaments = "
-//                         << n_members_
-//                         << ", n_bonds = " << members_[0].GetNBonds()
-//                         << ", n_avg_steps = " << orientation_corr_n_steps_
-//                         << "\n";
-//  orientation_corr_file_ << "time orientation_corr_avg
-//  orientation_corr_sem\n";
-//}
-
-// void RigidFilamentSpecies::RunOrientationCorrelationAnalysis() {
-//  if (time_ % orientation_corr_n_steps_ == 0) {
-//    for (auto it = members_.begin(); it != members_.end(); ++it) {
-//      it->ZeroOrientationCorrelations();
-//    }
-//    orientation_corr_file_ << "0 1 0\n";
-//    return;
-//  }
-//  double avg = 0;
-//  double sem = 0;
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    std::pair<double, double> avg_var = it->GetAvgOrientationCorrelation();
-//    avg += avg_var.first;
-//    sem += avg_var.second;
-//  }
-//  avg /= n_members_;
-//  sem = sem / n_members_;  // This calculates the pooled variance
-//  sem =
-//      sqrt(sem / (n_members_ * members_[0].GetNBonds()));  // """ standard
-//      error
-//  orientation_corr_file_ << time_ % orientation_corr_n_steps_ << " " << avg
-//                         << " " << sem << "\n";
-//}
-
-// void RigidFilamentSpecies::FinalizeOrientationCorrelationAnalysis() {}
-
-// void RigidFilamentSpecies::InitCrossingAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.crossing");
-//  crossing_file_.open(fname, std::ios::out);
-//  crossing_file_ << "crossing_analysis\n";
-//  crossing_file_ << "sp lp dr\n";
-//  crossing_file_ << params_->soft_potential_mag << " " <<
-//  sparams_.perlen_ratio
-//                 << " " << sparams_.driving_factor << "\n";
-//  double avg_u[3] = {0, 0, 0};
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    it->GetAvgOrientation(avg_u);
-//    crossing_file_ << acos(avg_u[1]) << " ";
-//  }
-//  crossing_file_ << "\n";
-//}
-
-// void RigidFilamentSpecies::RunCrossingAnalysis() {}
-
-// void RigidFilamentSpecies::FinalizeCrossingAnalysis() {
-//  double avg_pos[3] = {0, 0, 0};
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    it->GetAvgPosition(avg_pos);
-//    crossing_file_ << (avg_pos[0] > 2 ? 1 : 0) << " ";
-//  }
-//  crossing_file_ << "\n";
-//}
-
-// void RigidFilamentSpecies::InitMse2eAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.mse2e");
-//  mse2e_file_.open(fname, std::ios::out);
-//  mse2e_file_ << "mse2e_analysis_file\n";
-//  mse2e_file_ << "length diameter bond_length persistence_length driving ndim
-//  "
-//                 "nsteps nspec delta theory\n";
-//  auto it = members_.begin();
-//  double l = it->GetLength();
-//  double d = it->GetDiameter();
-//  double cl = it->GetBondLength();
-//  double pl = it->GetPersistenceLength();
-//  double dr = it->GetDriving();
-//  double nspec = GetNSpec();
-//  double theory;
-//  if (params_->n_dim == 2) {
-//    theory = l * pl * 4.0 - 8.0 * pl * pl * (1 - exp(-0.5 * l / pl));
-//  } else {
-//    theory = l * pl * 2.0 - 2.0 * pl * pl * (1 - exp(-l / pl));
-//  }
-//  mse2e_file_ << l << " " << d << " " << cl << " " << pl << " " << dr << " "
-//              << params_->n_dim << " " << params_->n_steps << " " << nspec
-//              << " " << params_->delta << " " << theory << "\n";
-//  mse2e_file_ << "num_filaments_averaged mse2e_mean mse2e_std_err\n";
-//  mse2e_ = 0.0;
-//  mse2e2_ = 0.0;
-//  n_samples_ = 0;
-//}
-
-// void RigidFilamentSpecies::InitSpiralAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.spiral");
-//  spiral_file_.open(fname, std::ios::out);
-//  spiral_file_ << "spiral_analysis_file\n";
-//  spiral_file_ << "length diameter bond_length persistence_length driving "
-//                  "nsteps nspec delta\n";
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    double l = it->GetLength();
-//    double d = it->GetDiameter();
-//    double cl = it->GetBondLength();
-//    double pl = it->GetPersistenceLength();
-//    double dr = it->GetDriving();
-//    double nspec = GetNSpec();
-//    spiral_file_ << l << " " << d << " " << cl << " " << pl << " " << dr << "
-//    "
-//                 << params_->n_steps << " " << nspec << " " << params_->delta
-//                 << "\n";
-//  }
-//  spiral_file_ << "time angle_sum E_bend tip_z_proj spiral_number head_pos_x "
-//                  "head_pos_y tail_pos_x tail_pos_y\n";
-//}
-
-// void RigidFilamentSpecies::InitThetaAnalysis() {
-//  // TODO Should check to make sure the same lengths, child lengths,
-//  persistence
-//  // lengths, etc are used for each filament in system.
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.theta");
-//  theta_file_.open(fname, std::ios::out);
-//  theta_file_ << "theta_analysis_file\n";
-//  theta_file_
-//      << "length diameter bond_length persistence_length driving n_filaments "
-//         "n_bonds n_steps n_spec delta n_dim \n";
-//  double l, cl, pl, dr, d;
-//  int nbonds;
-//  int nmembers = members_.size();
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    l = it->GetLength();
-//    d = it->GetDiameter();
-//    cl = it->GetBondLength();
-//    pl = it->GetPersistenceLength();
-//    dr = it->GetDriving();
-//    nbonds = it->GetNBonds();
-//  }
-//  int nspec = GetNSpec();
-//  theta_file_ << l << " " << d << " " << cl << " " << pl << " " << dr << " "
-//              << nmembers << " " << nbonds << " " << params_->n_steps << " "
-//              << nspec << " " << params_->delta << " " << params_->n_dim
-//              << "\n";
-//  theta_file_ << "cos_theta";
-//  for (int i = 0; i < nbonds - 1; ++i) {
-//    theta_file_ << " theta_" << i + 1 << i + 2;
-//  }
-//  theta_file_ << "\n";
-//  n_bins_ = 10000;
-//  theta_histogram_ = new int *[nbonds - 1];
-//  for (int ibond = 0; ibond < nbonds - 1; ++ibond) {
-//    theta_histogram_[ibond] = new int[n_bins_];
-//    for (int ibin = 0; ibin < n_bins_; ++ibin) {
-//      theta_histogram_[ibond][ibin] = 0;
-//    }
-//  }
-//}
-
-// void RigidFilamentSpecies::RunAnalysis() {
-//  if (sparams_.spiral_flag) {
-//    RunSpiralAnalysis();
-//  }
-//  // TODO Analyze conformation and ms end-to-end
-//  if (sparams_.theta_analysis) {
-//    RunThetaAnalysis();
-//  }
-//  if (sparams_.lp_analysis) {
-//    RunMse2eAnalysis();
-//  }
-//  if (sparams_.global_order_analysis) {
-//    RunGlobalOrderAnalysis();
-//  }
-//  if (params_->polar_order_analysis) {
-//    RunPolarOrderAnalysis();
-//  }
-//  if (sparams_.orientation_corr_analysis) {
-//    RunOrientationCorrelationAnalysis();
-//  }
-//  if (sparams_.flocking_analysis) {
-//    RunFlockingAnalysis();
-//  }
-//  time_++;
-//}
-
-// void RigidFilamentSpecies::RunGlobalOrderAnalysis() {
-//  double sn_tot = 0.0;
-//  double sn_mag = 0.0;
-//  double sn_spools = 0;
-//  int n_spooling = 0;
-//  double sn;
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    it->CalculateSpiralNumber();
-//    sn = it->GetSpiralNumber();
-//    it->GetPolarOrder(polar_order_vector_);
-//    it->GetNematicOrder(nematic_order_tensor_);
-//    sn_mag += ABS(sn);
-//    sn_tot += sn;
-//    if (sn > 0.7) {
-//      sn_spools += sn;
-//      n_spooling++;
-//    }
-//  }
-//  sn_mag /= n_members_;
-//  sn_tot /= n_members_;
-//  if (n_spooling > 0) {
-//    sn_spools /= n_spooling;
-//  } else {
-//    sn_spools = 0;
-//  }
-//  for (int i = 0; i < 3; ++i) {
-//    polar_order_vector_[i] /= n_members_;
-//  }
-//  for (int i = 0; i < 9; ++i) {
-//    nematic_order_tensor_[i] /= n_members_;
-//  }
-//  if (global_order_file_.is_open()) {
-//    global_order_file_ << time_ << " " << polar_order_vector_[0] << " "
-//                       << polar_order_vector_[1] << " "
-//                       << polar_order_vector_[2] << " "
-//                       << nematic_order_tensor_[0] << " "
-//                       << nematic_order_tensor_[1] << " "
-//                       << nematic_order_tensor_[2] << " "
-//                       << nematic_order_tensor_[3] << " "
-//                       << nematic_order_tensor_[4] << " "
-//                       << nematic_order_tensor_[5] << " "
-//                       << nematic_order_tensor_[6] << " "
-//                       << nematic_order_tensor_[7] << " "
-//                       << nematic_order_tensor_[8] << " " << sn_mag << " "
-//                       << sn_tot << " " << n_spooling << " " << sn_spools
-//                       << "\n";
-//  } else {
-//    Logger::Error("Problem opening file in RunGlobalOrderAnalysis!");
-//  }
-//}
-
-// void RigidFilamentSpecies::RunSpiralAnalysis() {
-//  // Treat as though we have many spirals for now
-//  double tip_z;
-//  auto it = members_.begin();
-//  e_bend_ = tot_angle_ = 0;
-//  double length = it->GetLength();
-//  double plength = it->GetPersistenceLength();
-//  double clength = it->GetBondLength();
-//  double e_zero = length * plength / (clength * clength);
-//  it->CalculateSpiralNumber();
-//  double spiral_number = it->GetSpiralNumber();
-//  std::vector<double> const *const thetas = it->GetThetas();
-//  for (int i = 0; i < thetas->size(); ++i) {
-//    tot_angle_ += acos((*thetas)[i]);
-//    e_bend_ += (*thetas)[i];
-//  }
-//  // record energy relative to the bending "zero energy" (straight rod)
-//  e_bend_ = e_zero - e_bend_ * plength / clength;
-//  tip_z = it->GetTipZ();
-//  double const *const head_pos = it->GetHeadPosition();
-//  double const *const tail_pos = it->GetTailPosition();
-//  if (spiral_file_.is_open()) {
-//    spiral_file_ << time_ << " " << tot_angle_ << " " << e_bend_ << " " <<
-//    tip_z
-//                 << " " << spiral_number << " " << head_pos[0] << " "
-//                 << head_pos[1] << " " << tail_pos[0] << " " << tail_pos[1]
-//                 << "\n";
-//  } else {
-//    Logger::Error("Problem opening file in RunSpiralAnalysis!");
-//  }
-//}
-
-// void RigidFilamentSpecies::RunMse2eAnalysis() {
-//  // Treat as though we have many spirals for now
-//  // if ( ! mse2e_file_.is_open()) {
-//  // early_exit = true;
-//  // std::cout << " Error! Problem opening file in RunMse2eAnalysis!
-//  // Exiting.\n";
-//  //}
-//  // mse2e_file_ << time_;
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    double const *const head_pos = it->GetHeadPosition();
-//    double const *const tail_pos = it->GetTailPosition();
-//    double mse2e_temp = 0.0;
-//    for (int i = 0; i < params_->n_dim; ++i) {
-//      double temp = (head_pos[i] - tail_pos[i]);
-//      mse2e_temp += temp * temp;
-//    }
-//    mse2e_ += mse2e_temp;
-//    mse2e2_ += mse2e_temp * mse2e_temp;
-//    // mse2e_file_ << " " << mse2e ;
-//  }
-//  // mse2e_ /= members_.size();
-//  // mse2e2_ /= members_.size();
-//  // mse2e_file_ << "\n";
-//  n_samples_++;
-//}
-
-// void RigidFilamentSpecies::RunThetaAnalysis() {
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    std::vector<double> const *const thetas = it->GetThetas();
-//    for (int i = 0; i < (it->GetNBonds() - 1); ++i) {
-//      int bin_number = (int)floor((1 + (*thetas)[i]) * (n_bins_ / 2));
-//      if (bin_number == n_bins_) {
-//        bin_number = n_bins_ - 1;
-//      } else if (bin_number == -1) {
-//        bin_number = 0;
-//      } else if (bin_number > n_bins_ && bin_number < 0) {
-//        Logger::Error("Something went wrong in RunThetaAnalysis!");
-//      }
-//      theta_histogram_[i][bin_number]++;
-//    }
-//  }
-//}
-
-// void RigidFilamentSpecies::FinalizeAnalysis() {
-//  if (spiral_file_.is_open()) {
-//    spiral_file_.close();
-//  }
-//  if (theta_file_.is_open()) {
-//    FinalizeThetaAnalysis();
-//    theta_file_.close();
-//  }
-//  if (crossing_file_.is_open()) {
-//    FinalizeCrossingAnalysis();
-//    crossing_file_.close();
-//  }
-//  if (mse2e_file_.is_open()) {
-//    FinalizeMse2eAnalysis();
-//    mse2e_file_.close();
-//  }
-//  if (global_order_file_.is_open()) {
-//    FinalizeGlobalOrderAnalysis();
-//    global_order_file_.close();
-//  }
-//  if (polar_order_file_.is_open()) {
-//    FinalizePolarOrderAnalysis();
-//    polar_order_file_.close();
-//    polar_order_avg_file_.close();
-//  }
-//  if (orientation_corr_file_.is_open()) {
-//    FinalizeOrientationCorrelationAnalysis();
-//    orientation_corr_file_.close();
-//  }
-//  if (flock_file_.is_open()) {
-//    FinalizeFlockingAnalysis();
-//    flock_file_.close();
-//  }
-//  if (in_out_file_.is_open()) {
-//    in_out_file_ << "angle_out: ";
-//    if (members_.size() < 2) {
-//      Logger::Error(
-//          "Error in in-out analysis in
-//          RigidFilamentSpecies::FinalizeAnalysis");
-//    }
-//    double u1[3] = {0, 0, 0};
-//    double u2[3] = {0, 0, 0};
-//    members_[0].GetAvgOrientation(u1);
-//    members_[1].GetAvgOrientation(u2);
-//    double dp = dot_product(params_->n_dim, u1, u2);
-//    in_out_file_ << acos(dp) << "\n";
-//    in_out_file_.close();
-//  }
-//}
-
-// void RigidFilamentSpecies::FinalizeGlobalOrderAnalysis() {}
-
-// void RigidFilamentSpecies::FinalizePolarOrderAnalysis() {
-/* In order to avoid overcounting cases where there were no local interactors
- * to count for local polar order, I am going to smooth the bin representing
- * (0,0) in the histogram, by averaging vertically along the y-axis */
-//  int avg_bin = (int)floor(
-//      0.5 * (polar_order_histogram_[(n_bins_1d_ / 2 - 1) * n_bins_1d_] +
-//             polar_order_histogram_[(n_bins_1d_ / 2 + 1) * n_bins_1d_]));
-//  polar_order_histogram_[(n_bins_1d_ / 2) * n_bins_1d_] = avg_bin;
-//  for (int i = 0; i < n_bins_1d_; ++i) {
-//    for (int j = 0; j < n_bins_1d_; ++j) {
-//      polar_order_file_
-//          << polar_order_histogram_[(n_bins_1d_ - 1 - i) * n_bins_1d_ + j]
-//          << " ";
-//    }
-//    polar_order_file_ << "\n";
-//  }
-//}
-
-//// void RigidFilamentSpecies::FinalizeLocalOrderAnalysis() {
-//// if (params_->local_structure_average) {
-//// WriteLocalOrderData();
-////}
-////}
-
-// void RigidFilamentSpecies::FinalizeMse2eAnalysis() {
-//  int num = members_.size();
-//  mse2e_file_ << num << " ";
-//  mse2e_ /= n_samples_ * num;
-//  mse2e2_ /= n_samples_ * num;
-//  mse2e_file_ << mse2e_ << " ";
-//  mse2e_file_ << sqrt((mse2e2_ - mse2e_ * mse2e_) / (num * n_samples_)) <<
-//  "\n";
-//}
-
-// void RigidFilamentSpecies::FinalizeThetaAnalysis() {
-//  int nbonds = members_[members_.size() - 1].GetNBonds();
-//  for (int i = 0; i < n_bins_; ++i) {
-//    double axis = (2.0 / n_bins_) * i - 1;
-//    theta_file_ << " " << axis;
-//    for (int ibond = 0; ibond < nbonds - 1; ++ibond) {
-//      theta_file_ << " " << theta_histogram_[ibond][i];
-//    }
-//    theta_file_ << "\n";
-//  }
-
-//  for (int ibond = 0; ibond < nbonds - 1; ++ibond) {
-//    delete[] theta_histogram_[ibond];
-//  }
-//  delete[] theta_histogram_;
-//}
-
-// void RigidFilamentSpecies::InitFlockingAnalysis() {
-//  std::string fname = params_->run_name;
-//  fname.append("_filament.flock");
-//  flock_file_.open(fname, std::ios::out);
-//  flock_file_ << "flock_analysis_file\n";
-//  flock_file_ << "length diameter bond_length persistence_length umax driving
-//  "
-//                 "nsteps nspec delta\n";
-//  auto it = members_.begin();
-//  double l = it->GetLength();
-//  double d = it->GetDiameter();
-//  double cl = it->GetBondLength();
-//  double pl = it->GetPersistenceLength();
-//  double dr = it->GetDriving();
-//  double nspec = GetNSpec();
-//  flock_file_ << l << " " << d << " " << cl << " " << pl << " "
-//              << params_->soft_potential_mag << " " << dr << " "
-//              << params_->n_steps << " " << nspec << " " << params_->delta
-//              << "\n";
-//  flock_file_ << "time n_flocking n_interior n_exterior n_joined n_left\n";
-//}
-
-// void RigidFilamentSpecies::RunFlockingAnalysis() {
-//  int n_flocking = 0;
-//  int n_interior = 0;
-//  int n_exterior = 0;
-//  int n_joined = 0;
-//  int n_left = 0;
-//  for (auto it = members_.begin(); it != members_.end(); ++it) {
-//    it->CheckFlocking();
-//    int flock_type = it->GetFlockType();
-//    int flock_change_state = it->GetFlockChangeState();
-//    if (flock_type) {
-//      n_flocking++;
-//      if (flock_type == 1) {
-//        n_interior++;
-//      } else if (flock_type == 2) {
-//        n_exterior++;
-//      } else {
-//        Logger::Warning(
-//            "Flock type not recognized in "
-//            "RigidFilamentSpecies::RunFlockingAnalysis");
-//      }
-//    }
-//    if (flock_change_state) {
-//      if (flock_change_state == 1) {
-//        n_joined++;
-//      } else if (flock_change_state == 2) {
-//        n_left++;
-//      } else {
-//        Logger::Warning(
-//            "Flock change state not recognized in "
-//            "RigidFilamentSpecies::RunFlockingAnalysis");
-//      }
-//    }
-//  }
-//  if (flock_file_.is_open()) {
-//    flock_file_ << time_ << " " << n_flocking << " " << n_interior << " "
-//                << n_exterior << " " << n_joined << " " << n_left << "\n";
-//  } else {
-//    Logger::Error("Problem opening file in RunFlockingAnalysis!");
-//  }
-//}
-
-// void RigidFilamentSpecies::FinalizeFlockingAnalysis() {}


### PR DESCRIPTION
## Description of changes
When constrain_motion_flag = true for rigid_filament objects, filament pairs will remain confined to separate parallel planes, preventing filament overlaps.

## Changes in behavior
No changes if constrain_motion_flag = false.

## Anything unresolved?
Is only valid when rigid_filament number = 2. Add checks to make sure this condition is met when constrain_motion_flag is set to true.