### PR TITLE
Kmc time step testing

### DIFF
--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -3,6 +3,7 @@
 
 #include "crosslink.hpp"
 #include "species.hpp"
+#include <KMC/kmc.hpp>
 
 typedef std::vector<std::pair<std::vector<Crosslink>::iterator,
                               std::vector<Crosslink>::iterator>>
@@ -10,11 +11,11 @@ typedef std::vector<std::pair<std::vector<Crosslink>::iterator,
 typedef std::vector<Crosslink>::iterator xlink_iterator;
 
 class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
- private:
+private:
   bool *update_;
   bool midstep_ = true;
   std::string checkpoint_file_;
-  double *obj_volume_;  // Total length of all the objects in the system
+  double *obj_volume_; // Total length of all the objects in the system
   double xlink_concentration_;
   double bind_site_density_;
   bool infinite_reservoir_flag_;
@@ -32,11 +33,12 @@ class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
   void ApplyCrosslinkTetherForces();
   Object *GetRandomObject();
 
- public:
+public:
   CrosslinkSpecies(unsigned long seed);
   void Init(std::string spec_name, ParamsParser &parser);
   void InitInteractionEnvironment(std::vector<Object *> *objs, double *obj_vol,
                                   bool *update);
+  void TestKMCStepSize();
   void GetInteractors(std::vector<Object *> &ixors);
   void UpdatePositions();
   void CleanUp();

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -325,12 +325,12 @@ void InteractionManager::ZeroDrTot() {
 }
 
 void InteractionManager::ProcessPairInteraction(ix_iterator ix) {
-  if (processing_ ) {
+  if (processing_) {
     mindist_.ObjectObject(*ix);
-     //Check to see if particles are not close enough to interact
+    //Check to see if particles are not close enough to interact
     if (ix->dr_mag2 > potentials_.GetRCut2())
       return;
-     //Calculates forces from the potential defined during initialization
+    //Calculates forces from the potential defined during initialization
     potentials_.CalcPotential(*ix);
     return;
   }


### PR DESCRIPTION
## Description of changes
crosslink_species now checks if KMC parameters are acceptable based on time step (delta). The largest possible time step is compared for dynamic time stepping. Dynamic time stepping should now also work when using basic Forward Euler integration as well as the midstep integrator.

## Changes in behavior
If multiple KMC events in a single time step are likely because of the size of binding or unbinding parameters (concentration, binding_site_density, k_on_s, k_off_s, etc.), the program will stop and ask you to change the parameters or max time step before continuing.

no_midstep flag now works as expected.

## Anything unresolved?
No
