### PR TITLE
added begin_with_crosslinks

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -292,7 +292,7 @@ crosslink:                          # Parameters specific to crosslinks.
                                     # Units in #/area or #/vol in 2D or 3D for free xlinks. In
                                     # #/area for grid spacing. In #/length or #/area for 2D or 3D
                                     # boundaries.
-  begin_with_crosslinks: [0, int]   # if greater than 0 the simultion begins with the specified number
+  begin_with_bound_crosslinks: [0, int]   # if greater than 0 the simultion begins with the specified number
                                     # of crosslinkers singly attached to microtubules
   use_binding_volume: [true, bool]  # Calculate concentration of unbound head of 
                                     # singly bound protein by finding a binding 

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -292,6 +292,8 @@ crosslink:                          # Parameters specific to crosslinks.
                                     # Units in #/area or #/vol in 2D or 3D for free xlinks. In
                                     # #/area for grid spacing. In #/length or #/area for 2D or 3D
                                     # boundaries.
+  begin_with_crosslinks: [0, int]   # if greater than 0 the simultion begins with the specified number
+                                    # of crosslinkers singly attached to microtubules
   use_binding_volume: [true, bool]  # Calculate concentration of unbound head of 
                                     # singly bound protein by finding a binding 
                                     # volume in which it is statistically likely

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -44,6 +44,8 @@ class CrosslinkManager {
   const double GetDrMax();
   void ReadInputs();
   void InsertCrosslinks();
+  void BeginWithCrosslinks();
+  void BeginWithCrosslinkers();
   const double GetRCutoff() const {
     Logger::Trace("Crosslink rcutoff is %2.2f", rcutoff_);
     return rcutoff_;

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -44,8 +44,7 @@ class CrosslinkManager {
   const double GetDrMax();
   void ReadInputs();
   void InsertCrosslinks();
-  void BeginWithCrosslinks();
-  void BeginWithCrosslinkers();
+  void InsertAttachedCrosslinks();
   const double GetRCutoff() const {
     Logger::Trace("Crosslink rcutoff is %2.2f", rcutoff_);
     return rcutoff_;

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -16,7 +16,7 @@ class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
   std::string checkpoint_file_;
   double *obj_volume_;  // Total length of all the objects in the system
   double xlink_concentration_;
-  int begin_with_crosslinks_;
+  int begin_with_bound_crosslinks_;
   double bind_site_density_;
   bool infinite_reservoir_flag_;
   double k_on_;
@@ -45,7 +45,7 @@ class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
   void BindCrosslinkObj(Object *obj);
   void AddNeighborToAnchor(Object *anchor, Object *neighbor);
   void AddMember();
-  void BeginWithCrosslinkers();
+  void InsertAttachedCrosslinksSpecies();
   void GetAnchorInteractors(std::vector<Object *> &ixors);
   void ReadSpecs();
   void InsertCrosslinks();

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -16,6 +16,7 @@ class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
   std::string checkpoint_file_;
   double *obj_volume_;  // Total length of all the objects in the system
   double xlink_concentration_;
+  int begin_with_crosslinks_;
   double bind_site_density_;
   bool infinite_reservoir_flag_;
   double k_on_;
@@ -44,6 +45,7 @@ class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
   void BindCrosslinkObj(Object *obj);
   void AddNeighborToAnchor(Object *anchor, Object *neighbor);
   void AddMember();
+  void BeginWithCrosslinkers();
   void GetAnchorInteractors(std::vector<Object *> &ixors);
   void ReadSpecs();
   void InsertCrosslinks();

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -112,7 +112,7 @@
   default_config["spindle"]["spring_length"] = "0";
   default_config["spindle"]["spb_diameter"] = "5";
   default_config["crosslink"]["concentration"] = "0";
-  default_config["crosslink"]["begin_with_crosslinks"] = "0";
+  default_config["crosslink"]["begin_with_bound_crosslinks"] = "0";
   default_config["crosslink"]["use_binding_volume"] = "true";
   default_config["crosslink"]["infinite_reservoir_flag"] = "false";
   default_config["crosslink"]["bind_site_density"] = "1";

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -17,13 +17,15 @@
   default_config["rigid_filament"]["stationary_flag"] = "false";
   default_config["rigid_filament"]["packing_fraction"] = "-1";
   default_config["rigid_filament"]["n_equil"] = "0";
-  default_config["filament"]["packing_fraction"] = "-1";
+  default_config["filament"]["randomize_intrinsic_curvature_handedness"] = "false";
   default_config["filament"]["persistence_length"] = "400";
+  default_config["filament"]["packing_fraction"] = "-1";
   default_config["filament"]["perlen_ratio"] = "-1";
   default_config["filament"]["polydispersity_flag"] = "false";
   default_config["filament"]["max_length"] = "500";
   default_config["filament"]["min_length"] = "5";
   default_config["filament"]["min_bond_length"] = "1.5";
+  default_config["filament"]["flock_color_ext"] = "4.71";
   default_config["filament"]["driving_factor"] = "0";
   default_config["filament"]["n_equil"] = "0";
   default_config["filament"]["nematic_driving"] = "false";
@@ -33,7 +35,6 @@
   default_config["filament"]["radius_of_curvature"] = "-1";
   default_config["filament"]["intrinsic_curvature"] = "0";
   default_config["filament"]["intrinsic_curvature_sig"] = "0";
-  default_config["filament"]["randomize_intrinsic_curvature_handedness"] = "false";
   default_config["filament"]["intrinsic_curvature_min"] = "0";
   default_config["filament"]["highlight_handedness"] = "false";
   default_config["filament"]["highlight_curvature"] = "false";
@@ -61,7 +62,7 @@
   default_config["filament"]["flock_contact_min"] = "0.5";
   default_config["filament"]["highlight_flock"] = "false";
   default_config["filament"]["flock_color_int"] = "1.57";
-  default_config["filament"]["flock_color_ext"] = "4.71";
+  default_config["filament"]["force_induced_catastrophe_flag"] = "false";
   default_config["filament"]["number_fluctuation_analysis"] = "false";
   default_config["filament"]["number_fluctuation_boxes"] = "6";
   default_config["filament"]["number_fluctuation_centers"] = "10";
@@ -73,7 +74,6 @@
   default_config["filament"]["flagella_amplitude"] = "1";
   default_config["filament"]["friction_ratio"] = "2";
   default_config["filament"]["dynamic_instability_flag"] = "false";
-  default_config["filament"]["force_induced_catastrophe_flag"] = "false";
   default_config["filament"]["optical_trap_flag"] = "false";
   default_config["filament"]["optical_trap_spring"] = "20";
   default_config["filament"]["optical_trap_fixed"] = "false";
@@ -112,6 +112,7 @@
   default_config["spindle"]["spring_length"] = "0";
   default_config["spindle"]["spb_diameter"] = "5";
   default_config["crosslink"]["concentration"] = "0";
+  default_config["crosslink"]["begin_with_crosslinks"] = "0";
   default_config["crosslink"]["use_binding_volume"] = "true";
   default_config["crosslink"]["infinite_reservoir_flag"] = "false";
   default_config["crosslink"]["bind_site_density"] = "1";
@@ -123,11 +124,11 @@
   default_config["crosslink"]["k_on_s"] = "10";
   default_config["crosslink"]["k_off_s"] = "2";
   default_config["crosslink"]["k_on_d"] = "10";
+  default_config["crosslink"]["k_spring"] = "10";
   default_config["crosslink"]["k_off_d"] = "2";
   default_config["crosslink"]["energy_dep_factor"] = "0";
   default_config["crosslink"]["force_dep_length"] = "0";
   default_config["crosslink"]["polar_affinity"] = "1";
-  default_config["crosslink"]["k_spring"] = "10";
   default_config["crosslink"]["k_spring_compress"] = "-1.";
   default_config["crosslink"]["f_stall"] = "100";
   default_config["crosslink"]["force_dep_vel_flag"] = "true";
@@ -141,7 +142,10 @@
   default_config["crosslink"]["r_capture"] = "5";
   default_config["crosslink"]["lut_grid_num"] = "256";
   default_config["seed"] = "7859459105545";
+  default_config["species_insertion_reattempt_threshold"] = "10";
+  default_config["species_insertion_failure_threshold"] = "10000";
   default_config["n_runs"] = "1";
+  default_config["coarse_grained_mesh_interactions"] = "false";
   default_config["n_random"] = "1";
   default_config["run_name"] = "sc";
   default_config["n_dim"] = "3";
@@ -186,10 +190,7 @@
   default_config["insert_radius"] = "-1";
   default_config["interaction_flag"] = "true";
   default_config["remove_duplicate_interactions"] = "false";
-  default_config["coarse_grained_mesh_interactions"] = "false";
   default_config["mesh_coarsening"] = "2";
-  default_config["species_insertion_failure_threshold"] = "10000";
-  default_config["species_insertion_reattempt_threshold"] = "10";
   default_config["uniform_crystal"] = "false";
   default_config["n_steps_equil"] = "0";
   default_config["n_steps_target"] = "100000";
@@ -202,6 +203,7 @@
   default_config["auto_graph"] = "false";
   default_config["local_order_analysis"] = "false";
   default_config["local_order_width"] = "50";
+  default_config["reduced"] = "false";
   default_config["local_order_bin_width"] = "0.5";
   default_config["local_order_n_analysis"] = "100";
   default_config["density_analysis"] = "0";
@@ -209,7 +211,6 @@
   default_config["density_com_only"] = "false";
   default_config["overlap_analysis"] = "false";
   default_config["highlight_overlaps"] = "false";
-  default_config["reduced"] = "false";
   default_config["reload_reduce_switch"] = "false";
   default_config["checkpoint_flag"] = "false";
   default_config["n_checkpoint"] = "10000";

--- a/include/cglass/interaction_manager.hpp
+++ b/include/cglass/interaction_manager.hpp
@@ -97,6 +97,7 @@ class InteractionManager {
   void LoadCrosslinksFromCheckpoints(std::string run_name,
                                      std::string checkpoint_run_name);
   void InsertCrosslinks();
+  void BeginWithCrosslinks();
   void SetInteractionAnalysis(bool set) { run_interaction_analysis_ = set; }
 };
 

--- a/include/cglass/interaction_manager.hpp
+++ b/include/cglass/interaction_manager.hpp
@@ -97,7 +97,7 @@ class InteractionManager {
   void LoadCrosslinksFromCheckpoints(std::string run_name,
                                      std::string checkpoint_run_name);
   void InsertCrosslinks();
-  void BeginWithCrosslinks();
+  void InsertAttachedCrosslinks();
   void SetInteractionAnalysis(bool set) { run_interaction_analysis_ = set; }
 };
 

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -38,13 +38,15 @@ typedef species_parameters<species_id::rigid_filament> rigid_filament_parameters
 template <>
 struct species_parameters<species_id::filament>
     : public species_base_parameters {
-  double packing_fraction = -1;
+  bool randomize_intrinsic_curvature_handedness = false;
   double persistence_length = 400;
+  double packing_fraction = -1;
   double perlen_ratio = -1;
   bool polydispersity_flag = false;
   double max_length = 500;
   double min_length = 5;
   double min_bond_length = 1.5;
+  double flock_color_ext = 4.71;
   double driving_factor = 0;
   int n_equil = 0;
   bool nematic_driving = false;
@@ -54,7 +56,6 @@ struct species_parameters<species_id::filament>
   double radius_of_curvature = -1;
   double intrinsic_curvature = 0;
   double intrinsic_curvature_sig = 0;
-  bool randomize_intrinsic_curvature_handedness = false;
   double intrinsic_curvature_min = 0;
   bool highlight_handedness = false;
   bool highlight_curvature = false;
@@ -82,7 +83,7 @@ struct species_parameters<species_id::filament>
   double flock_contact_min = 0.5;
   bool highlight_flock = false;
   double flock_color_int = 1.57;
-  double flock_color_ext = 4.71;
+  bool force_induced_catastrophe_flag = false;
   bool number_fluctuation_analysis = false;
   int number_fluctuation_boxes = 6;
   int number_fluctuation_centers = 10;
@@ -94,7 +95,6 @@ struct species_parameters<species_id::filament>
   double flagella_amplitude = 1;
   double friction_ratio = 2;
   bool dynamic_instability_flag = false;
-  bool force_induced_catastrophe_flag = false;
   bool optical_trap_flag = false;
   double optical_trap_spring = 20;
   bool optical_trap_fixed = false;
@@ -157,6 +157,7 @@ template <>
 struct species_parameters<species_id::crosslink>
     : public species_base_parameters {
   double concentration = 0;
+  int begin_with_crosslinks = 0;
   bool use_binding_volume = true;
   bool infinite_reservoir_flag = false;
   double bind_site_density = 1;
@@ -168,11 +169,11 @@ struct species_parameters<species_id::crosslink>
   double k_on_s = 10;
   double k_off_s = 2;
   double k_on_d = 10;
+  double k_spring = 10;
   double k_off_d = 2;
   double energy_dep_factor = 0;
   double force_dep_length = 0;
   double polar_affinity = 1;
-  double k_spring = 10;
   double k_spring_compress = -1.;
   double f_stall = 100;
   bool force_dep_vel_flag = true;
@@ -190,7 +191,10 @@ typedef species_parameters<species_id::crosslink> crosslink_parameters;
 
 struct system_parameters {
   long seed = 7859459105545;
+  int species_insertion_reattempt_threshold = 10;
+  int species_insertion_failure_threshold = 10000;
   int n_runs = 1;
+  bool coarse_grained_mesh_interactions = false;
   int n_random = 1;
   std::string run_name = "sc";
   int n_dim = 3;
@@ -235,10 +239,7 @@ struct system_parameters {
   double insert_radius = -1;
   bool interaction_flag = true;
   bool remove_duplicate_interactions = false;
-  bool coarse_grained_mesh_interactions = false;
   int mesh_coarsening = 2;
-  int species_insertion_failure_threshold = 10000;
-  int species_insertion_reattempt_threshold = 10;
   bool uniform_crystal = false;
   int n_steps_equil = 0;
   int n_steps_target = 100000;
@@ -251,6 +252,7 @@ struct system_parameters {
   bool auto_graph = false;
   bool local_order_analysis = false;
   double local_order_width = 50;
+  bool reduced = false;
   double local_order_bin_width = 0.5;
   int local_order_n_analysis = 100;
   int density_analysis = 0;
@@ -258,7 +260,6 @@ struct system_parameters {
   bool density_com_only = false;
   bool overlap_analysis = false;
   bool highlight_overlaps = false;
-  bool reduced = false;
   bool reload_reduce_switch = false;
   bool checkpoint_flag = false;
   int n_checkpoint = 10000;

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -157,7 +157,7 @@ template <>
 struct species_parameters<species_id::crosslink>
     : public species_base_parameters {
   double concentration = 0;
-  int begin_with_crosslinks = 0;
+  int begin_with_bound_crosslinks = 0;
   bool use_binding_volume = true;
   bool infinite_reservoir_flag = false;
   double bind_site_density = 1;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -14,8 +14,14 @@ system_parameters parse_system_params(YAML::Node &node) {
     if (false) {
     } else if (param_name.compare("seed")==0) {
     params.seed = it->second.as<long>();
+    } else if (param_name.compare("species_insertion_reattempt_threshold")==0) {
+    params.species_insertion_reattempt_threshold = it->second.as<int>();
+    } else if (param_name.compare("species_insertion_failure_threshold")==0) {
+    params.species_insertion_failure_threshold = it->second.as<int>();
     } else if (param_name.compare("n_runs")==0) {
     params.n_runs = it->second.as<int>();
+    } else if (param_name.compare("coarse_grained_mesh_interactions")==0) {
+    params.coarse_grained_mesh_interactions = it->second.as<bool>();
     } else if (param_name.compare("n_random")==0) {
     params.n_random = it->second.as<int>();
     } else if (param_name.compare("run_name")==0) {
@@ -104,14 +110,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.interaction_flag = it->second.as<bool>();
     } else if (param_name.compare("remove_duplicate_interactions")==0) {
     params.remove_duplicate_interactions = it->second.as<bool>();
-    } else if (param_name.compare("coarse_grained_mesh_interactions")==0) {
-    params.coarse_grained_mesh_interactions = it->second.as<bool>();
     } else if (param_name.compare("mesh_coarsening")==0) {
     params.mesh_coarsening = it->second.as<int>();
-    } else if (param_name.compare("species_insertion_failure_threshold")==0) {
-    params.species_insertion_failure_threshold = it->second.as<int>();
-    } else if (param_name.compare("species_insertion_reattempt_threshold")==0) {
-    params.species_insertion_reattempt_threshold = it->second.as<int>();
     } else if (param_name.compare("uniform_crystal")==0) {
     params.uniform_crystal = it->second.as<bool>();
     } else if (param_name.compare("n_steps_equil")==0) {
@@ -136,6 +136,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.local_order_analysis = it->second.as<bool>();
     } else if (param_name.compare("local_order_width")==0) {
     params.local_order_width = it->second.as<double>();
+    } else if (param_name.compare("reduced")==0) {
+    params.reduced = it->second.as<bool>();
     } else if (param_name.compare("local_order_bin_width")==0) {
     params.local_order_bin_width = it->second.as<double>();
     } else if (param_name.compare("local_order_n_analysis")==0) {
@@ -150,8 +152,6 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.overlap_analysis = it->second.as<bool>();
     } else if (param_name.compare("highlight_overlaps")==0) {
     params.highlight_overlaps = it->second.as<bool>();
-    } else if (param_name.compare("reduced")==0) {
-    params.reduced = it->second.as<bool>();
     } else if (param_name.compare("reload_reduce_switch")==0) {
     params.reload_reduce_switch = it->second.as<bool>();
     } else if (param_name.compare("checkpoint_flag")==0) {
@@ -295,10 +295,12 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_posit = jt->second.as<int>();
       } else if (param_name.compare("n_spec")==0) {
       params.n_spec = jt->second.as<int>();
-      } else if (param_name.compare("packing_fraction")==0) {
-      params.packing_fraction = jt->second.as<double>();
+      } else if (param_name.compare("randomize_intrinsic_curvature_handedness")==0) {
+      params.randomize_intrinsic_curvature_handedness = jt->second.as<bool>();
       } else if (param_name.compare("persistence_length")==0) {
       params.persistence_length = jt->second.as<double>();
+      } else if (param_name.compare("packing_fraction")==0) {
+      params.packing_fraction = jt->second.as<double>();
       } else if (param_name.compare("perlen_ratio")==0) {
       params.perlen_ratio = jt->second.as<double>();
       } else if (param_name.compare("polydispersity_flag")==0) {
@@ -309,6 +311,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.min_length = jt->second.as<double>();
       } else if (param_name.compare("min_bond_length")==0) {
       params.min_bond_length = jt->second.as<double>();
+      } else if (param_name.compare("flock_color_ext")==0) {
+      params.flock_color_ext = jt->second.as<double>();
       } else if (param_name.compare("driving_factor")==0) {
       params.driving_factor = jt->second.as<double>();
       } else if (param_name.compare("n_equil")==0) {
@@ -327,8 +331,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.intrinsic_curvature = jt->second.as<double>();
       } else if (param_name.compare("intrinsic_curvature_sig")==0) {
       params.intrinsic_curvature_sig = jt->second.as<double>();
-      } else if (param_name.compare("randomize_intrinsic_curvature_handedness")==0) {
-      params.randomize_intrinsic_curvature_handedness = jt->second.as<bool>();
       } else if (param_name.compare("intrinsic_curvature_min")==0) {
       params.intrinsic_curvature_min = jt->second.as<double>();
       } else if (param_name.compare("highlight_handedness")==0) {
@@ -383,8 +385,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.highlight_flock = jt->second.as<bool>();
       } else if (param_name.compare("flock_color_int")==0) {
       params.flock_color_int = jt->second.as<double>();
-      } else if (param_name.compare("flock_color_ext")==0) {
-      params.flock_color_ext = jt->second.as<double>();
+      } else if (param_name.compare("force_induced_catastrophe_flag")==0) {
+      params.force_induced_catastrophe_flag = jt->second.as<bool>();
       } else if (param_name.compare("number_fluctuation_analysis")==0) {
       params.number_fluctuation_analysis = jt->second.as<bool>();
       } else if (param_name.compare("number_fluctuation_boxes")==0) {
@@ -407,8 +409,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.friction_ratio = jt->second.as<double>();
       } else if (param_name.compare("dynamic_instability_flag")==0) {
       params.dynamic_instability_flag = jt->second.as<bool>();
-      } else if (param_name.compare("force_induced_catastrophe_flag")==0) {
-      params.force_induced_catastrophe_flag = jt->second.as<bool>();
       } else if (param_name.compare("optical_trap_flag")==0) {
       params.optical_trap_flag = jt->second.as<bool>();
       } else if (param_name.compare("optical_trap_spring")==0) {
@@ -633,6 +633,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("concentration")==0) {
       params.concentration = jt->second.as<double>();
+      } else if (param_name.compare("begin_with_crosslinks")==0) {
+      params.begin_with_crosslinks = jt->second.as<int>();
       } else if (param_name.compare("use_binding_volume")==0) {
       params.use_binding_volume = jt->second.as<bool>();
       } else if (param_name.compare("infinite_reservoir_flag")==0) {
@@ -655,6 +657,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.k_off_s = jt->second.as<double>();
       } else if (param_name.compare("k_on_d")==0) {
       params.k_on_d = jt->second.as<double>();
+      } else if (param_name.compare("k_spring")==0) {
+      params.k_spring = jt->second.as<double>();
       } else if (param_name.compare("k_off_d")==0) {
       params.k_off_d = jt->second.as<double>();
       } else if (param_name.compare("energy_dep_factor")==0) {
@@ -663,8 +667,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.force_dep_length = jt->second.as<double>();
       } else if (param_name.compare("polar_affinity")==0) {
       params.polar_affinity = jt->second.as<double>();
-      } else if (param_name.compare("k_spring")==0) {
-      params.k_spring = jt->second.as<double>();
       } else if (param_name.compare("k_spring_compress")==0) {
       params.k_spring_compress = jt->second.as<double>();
       } else if (param_name.compare("f_stall")==0) {

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -633,8 +633,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("concentration")==0) {
       params.concentration = jt->second.as<double>();
-      } else if (param_name.compare("begin_with_crosslinks")==0) {
-      params.begin_with_crosslinks = jt->second.as<int>();
+      } else if (param_name.compare("begin_with_bound_crosslinks")==0) {
+      params.begin_with_bound_crosslinks = jt->second.as<int>();
       } else if (param_name.compare("use_binding_volume")==0) {
       params.use_binding_volume = jt->second.as<bool>();
       } else if (param_name.compare("infinite_reservoir_flag")==0) {

--- a/src/crosslink_manager.cpp
+++ b/src/crosslink_manager.cpp
@@ -75,6 +75,12 @@ void CrosslinkManager::InsertCrosslinks() {
   }
 }
 
+void CrosslinkManager::BeginWithCrosslinks() {
+  for (auto it = xlink_species_.begin(); it != xlink_species_.end(); ++it) {
+    (*it)->BeginWithCrosslinkers();
+  }
+}
+
 void CrosslinkManager::Clear() {
   output_mgr_.Close();
   for (auto it = xlink_species_.begin(); it != xlink_species_.end(); ++it) {

--- a/src/crosslink_manager.cpp
+++ b/src/crosslink_manager.cpp
@@ -75,9 +75,9 @@ void CrosslinkManager::InsertCrosslinks() {
   }
 }
 
-void CrosslinkManager::BeginWithCrosslinks() {
+void CrosslinkManager::InsertAttachedCrosslinks() {
   for (auto it = xlink_species_.begin(); it != xlink_species_.end(); ++it) {
-    (*it)->BeginWithCrosslinkers();
+    (*it)->InsertAttachedCrosslinksSpecies();
   }
 }
 

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -7,7 +7,7 @@ void CrosslinkSpecies::Init(std::string spec_name, ParamsParser &parser) {
   Species::Init(spec_name, parser);
   k_on_ = sparams_.k_on_s;
   bind_site_density_ = sparams_.bind_site_density;
-  begin_with_crosslinks_ = sparams_.begin_with_crosslinks;
+  begin_with_bound_crosslinks_ = sparams_.begin_with_bound_crosslinks;
   xlink_concentration_ = sparams_.concentration;
   infinite_reservoir_flag_ = sparams_.infinite_reservoir_flag;
   sparams_.num = (int)round(sparams_.concentration * space_->volume);
@@ -150,18 +150,18 @@ void CrosslinkSpecies::InsertCrosslinks() {
   }
 }
 
-//Adds in Crosslinkers for begin_with_crosslinks flag
-void CrosslinkSpecies::BeginWithCrosslinkers() {
-  if (begin_with_crosslinks_<=0) {
+//Adds in Crosslinkers for begin_with_bound_crosslinks flag
+void CrosslinkSpecies::InsertAttachedCrosslinksSpecies() {
+  if (begin_with_bound_crosslinks_<=0) {
     return;
   }
   Crosslink xlink(rng_.GetSeed());
   xlink.Init(&sparams_);
   xlink.InitInteractionEnvironment(&lut_);
   xlink.SetSID(GetSID());
-  members_.resize(begin_with_crosslinks_, xlink);
+  members_.resize(begin_with_bound_crosslinks_, xlink);
   UpdateBoundCrosslinks();
-  for (int i=0; i < begin_with_crosslinks_; ++i) {
+  for (int i=0; i < begin_with_bound_crosslinks_; ++i) {
     BindCrosslink();
   }
 }

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -7,6 +7,7 @@ void CrosslinkSpecies::Init(std::string spec_name, ParamsParser &parser) {
   Species::Init(spec_name, parser);
   k_on_ = sparams_.k_on_s;
   bind_site_density_ = sparams_.bind_site_density;
+  begin_with_crosslinks_ = sparams_.begin_with_crosslinks;
   xlink_concentration_ = sparams_.concentration;
   infinite_reservoir_flag_ = sparams_.infinite_reservoir_flag;
   sparams_.num = (int)round(sparams_.concentration * space_->volume);
@@ -146,6 +147,22 @@ void CrosslinkSpecies::InsertCrosslinks() {
   } else {
     Logger::Error("Insertion type %s not implemented yet for crosslinks",
                   sparams_.insertion_type.c_str());
+  }
+}
+
+//Adds in Crosslinkers for begin_with_crosslinks flag
+void CrosslinkSpecies::BeginWithCrosslinkers() {
+  if (begin_with_crosslinks_<=0) {
+    return;
+  }
+  Crosslink xlink(rng_.GetSeed());
+  xlink.Init(&sparams_);
+  xlink.InitInteractionEnvironment(&lut_);
+  xlink.SetSID(GetSID());
+  members_.resize(begin_with_crosslinks_, xlink);
+  UpdateBoundCrosslinks();
+  for (int i=0; i < begin_with_crosslinks_; ++i) {
+    BindCrosslink();
   }
 }
 

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -757,8 +757,8 @@ void InteractionManager::LoadCrosslinksFromCheckpoints(
 
 void InteractionManager::InsertCrosslinks() { xlink_.InsertCrosslinks(); }
 
-void InteractionManager::BeginWithCrosslinks() {
-     xlink_.BeginWithCrosslinks();
+void InteractionManager::InsertAttachedCrosslinks() {
+     xlink_.InsertAttachedCrosslinks();
      ForceUpdate();
 }
 

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -757,6 +757,11 @@ void InteractionManager::LoadCrosslinksFromCheckpoints(
 
 void InteractionManager::InsertCrosslinks() { xlink_.InsertCrosslinks(); }
 
+void InteractionManager::BeginWithCrosslinks() {
+     xlink_.BeginWithCrosslinks();
+     ForceUpdate();
+}
+
 bool InteractionManager::CheckDynamicTimestep() {
   if (decrease_dynamic_timestep_) {
     for (auto spec_it = species_->begin(); spec_it != species_->end();

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -454,7 +454,7 @@ void Simulation::InsertSpecies(bool force_overlap, bool processing) {
   // if (!processing) {
   ix_mgr_.CheckUpdateObjects(); // Forces update as well
   //}  
-  ix_mgr_.BeginWithCrosslinks();
+  ix_mgr_.InsertAttachedCrosslinks();
 }
 
 /* Tear down data structures, e.g. cell lists, and close graphics window if

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -449,12 +449,12 @@ void Simulation::InsertSpecies(bool force_overlap, bool processing) {
     ix_mgr_.LoadCrosslinksFromCheckpoints(run_name_,
                                           params_.checkpoint_run_name);
   }
-
   ix_mgr_.ResetCellList(); // Forces rebuild cell list without redundancy
   ix_mgr_.Reset();
   // if (!processing) {
   ix_mgr_.CheckUpdateObjects(); // Forces update as well
-  //}
+  //}  
+  ix_mgr_.BeginWithCrosslinks();
 }
 
 /* Tear down data structures, e.g. cell lists, and close graphics window if


### PR DESCRIPTION


## Description of changes
Added begin_with_crosslinks_attached flag which causes the simulation to start out with the specified number of crosslinkers singly bound

## Changes in behavior
With begin_with_crosslinks off it shouldn't affect the behavior.

## Anything unresolved?
Nope
