### PR TITLE
New optical trap object and species

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -22,6 +22,7 @@ dynamic_timestep_ramp : [0.001, double]  # How quickly to return to default time
 graph_flag : [false, bool]           # Whether to run simulation with live graphics.
 n_graph : [1000, int]                # Number of simulation steps between refreshing graphics.
 graph_diameter : [0, double]         # If > 0, draws particles with a diameter of graph_diameter.
+object_opacity: [1, double]          # Sets opacity (alpha) for all sphero-like objects. 1.=opaque, 0.=invisible
 invert_background : [false, bool]    # If false, black background, otherwise white background.
 draw_boundary: [true, bool]          # If set to zero, does not draw system boundary conditions.
 load_checkpoint: [false, bool]       # Flag for reading checkpoint file corresponding to

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -343,3 +343,11 @@ crosslink:                          # Parameters specific to crosslinks.
                                     # Calculated using k_spring, rest_length. User input ignored.
   lut_grid_num: [256, int]          # Number of grid points used in one dimension of the the lookup table (LUT).
                                     # Total entries go as the square of this number e.g. 256 x 256
+optical_trap:
+  trap_spring: [1, double]          # Spring constant for optical trap, i.e. trap strength.
+  attach_species: [filament, string] # What species does the optical trap bind to.
+  trap_diameter: [4, double]          # Radius for graphically representing trap
+  bead_diameter: [2, double]          # Radius for graphically representing bead in trap
+  trap_color: [3.1416, double]      # Color for graphically representing trap
+  bead_color: [1.5708, double]      # Color for graphically representing bead in trap
+

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -141,6 +141,12 @@
   default_config["crosslink"]["end_pausing"] = "false";
   default_config["crosslink"]["r_capture"] = "5";
   default_config["crosslink"]["lut_grid_num"] = "256";
+  default_config["optical_trap"]["trap_spring"] = "1";
+  default_config["optical_trap"]["attach_species"] = "filament";
+  default_config["optical_trap"]["trap_diameter"] = "4";
+  default_config["optical_trap"]["bead_diameter"] = "2";
+  default_config["optical_trap"]["trap_color"] = "3.1416";
+  default_config["optical_trap"]["bead_color"] = "1.5708";
   default_config["seed"] = "7859459105545";
   default_config["n_runs"] = "1";
   default_config["n_random"] = "1";

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -164,6 +164,7 @@
   default_config["graph_flag"] = "false";
   default_config["n_graph"] = "1000";
   default_config["graph_diameter"] = "0";
+  default_config["object_opacity"] = "1";
   default_config["invert_background"] = "false";
   default_config["draw_boundary"] = "true";
   default_config["load_checkpoint"] = "false";

--- a/include/cglass/definitions.hpp
+++ b/include/cglass/definitions.hpp
@@ -1,8 +1,8 @@
 #ifndef _CGLASS_DEFINITIONS_H_
 #define _CGLASS_DEFINITIONS_H_
 
-#define BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum) \
- public:                                       \
+#define BETTER_ENUMS_DEFAULT_CONSTRUCTOR(Enum)                                 \
+public:                                                                        \
   Enum() = default;
 #include "enum.hpp"
 
@@ -11,13 +11,13 @@
 #endif
 
 BETTER_ENUM(species_id, unsigned char, br_bead, filament, rigid_filament,
-            spherocylinder, spindle, crosslink, none);
+            spherocylinder, spindle, crosslink, optical_trap, none);
 BETTER_ENUM(draw_type, unsigned char, fixed, orientation, bw, none);
 BETTER_ENUM(potential_type, unsigned char, none, wca, soft, lj);
 BETTER_ENUM(boundary_type, unsigned char, none = 0, box = 1, sphere = 2,
             budding = 3, wall = 4);
-BETTER_ENUM(poly_state, unsigned char, grow, shrink, pause);  // make these 0,
-                                                              // 1, 2 explicitly
+BETTER_ENUM(poly_state, unsigned char, grow, shrink, pause); // make these 0,
+                                                             // 1, 2 explicitly
 BETTER_ENUM(bind_state, unsigned char, unbound, singly, doubly);
 BETTER_ENUM(obj_type, unsigned char, generic, bond, site);
 
@@ -26,21 +26,21 @@ struct space_struct {
   int n_periodic;
   bool bud;
   double radius;
-  double pressure_tensor[9];  // pressure tensor
-  double pressure;            // isometric pressure
+  double pressure_tensor[9]; // pressure tensor
+  double pressure;           // isometric pressure
   double volume;
   double bud_radius;
   double bud_height;
   double bud_neck_radius;
   double bud_neck_height;
   double *unit_cell;
-  double *unit_cell_inv;  // inverse unit cell
-  double *a;              // direct lattice vector
-  double *b;              // reciprocal lattice vector
-  double *a_perp;  // perpendicular distance between opposite unit cell faces
-  double *mu;      // scaling matrix for constant pressure
-  int n_bound;     // number of bound motors
-  double concentration;  // C of motors
+  double *unit_cell_inv; // inverse unit cell
+  double *a;             // direct lattice vector
+  double *b;             // reciprocal lattice vector
+  double *a_perp; // perpendicular distance between opposite unit cell faces
+  double *mu;     // scaling matrix for constant pressure
+  int n_bound;    // number of bound motors
+  double concentration; // C of motors
   boundary_type type;
 };
 
@@ -60,8 +60,8 @@ struct graph_struct {
 //}
 
 #ifdef TESTS
-#define UNIT_TEST       \
-  template <typename T> \
+#define UNIT_TEST                                                              \
+  template <typename T>                                                        \
   friend class UnitTest;
 template <typename T>
 class UnitTest {};

--- a/include/cglass/graphics.hpp
+++ b/include/cglass/graphics.hpp
@@ -3,11 +3,11 @@
 
 #ifndef NOGRAPH
 
+#include "auxiliary.hpp"
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include <string>
 #include <vector>
-#include "auxiliary.hpp"
 #define GLEW_STATIC
 //#include <ft2build.h>
 //#include FT_FREETYPE_H
@@ -20,7 +20,7 @@ struct point {
 };
 
 class GraphicsPrimitive {
- public:
+public:
   GLuint vertex_buffer_, element_buffer_;
   GLuint vertex_shader_, fragment_shader_, program_;
   GLfloat *vertex_buffer_data_;
@@ -63,51 +63,51 @@ class GraphicsPrimitive {
 /* The <graphics_parameters> structure contains a variety of graphics
  * parameters. */
 class Graphics {
- public:
-  GLFWwindow *window_;  // Our actual window
-  int windx_;           // window x dimension in pixels
-  int windy_;           // window y dimension in pixels
+public:
+  GLFWwindow *window_; // Our actual window
+  int windx_;          // window x dimension in pixels
+  int windy_;          // window y dimension in pixels
 
-  int n_dim_;  // number of physical dimensions we're drawing
+  int n_dim_; // number of physical dimensions we're drawing
   int auto_graph_;
   double *unit_cell_;
-  double z_correct_;  // Used to recenter graphics
+  double z_correct_; // Used to recenter graphics
   space_struct *space_;
   std::vector<graph_struct *> *graph_array_;
 
-  GraphicsPrimitive discorectangle_;  // 2d spherocylinder
-  GraphicsPrimitive spherocylinder_;  // actual spherocylinder
+  GraphicsPrimitive discorectangle_; // 2d spherocylinder
+  GraphicsPrimitive spherocylinder_; // actual spherocylinder
   // GraphicsText text_;
 
-  GLfloat xAngle_, yAngle_, zAngle_;     // system rotation
-  GLfloat xyzScale_;                     // zoom
-  GLfloat xTrans_, yTrans_, zTrans_;     // translation of system
-  GLfloat zNear_, zFar_, cNear_, cFar_;  // camera positions and clipping planes
-  GLfloat cxAngle_, cyAngle_;            // clipping plane angles
+  GLfloat xAngle_, yAngle_, zAngle_;    // system rotation
+  GLfloat xyzScale_;                    // zoom
+  GLfloat xTrans_, yTrans_, zTrans_;    // translation of system
+  GLfloat zNear_, zFar_, cNear_, cFar_; // camera positions and clipping planes
+  GLfloat cxAngle_, cyAngle_;           // clipping plane angles
   GLfloat sphere_color_[3], box_color_[3], background_color_[3];
-  GLfloat alpha_;  // transparency (1 opaque, 0 invisible)
+  GLfloat alpha_; // transparency (1 opaque, 0 invisible)
 
   static const int n_rgb_ = 384;
   static const int shift_ = 84;
   GLfloat colormap_[n_rgb_ * 4];
 
-  int color_switch_;        // which coloring algorithm to use
-  int keep_going_;          // Allow to draw same configuration in loop
-  boundary_type boundary_;  // boundary type to draw. currently supports
-                            // "box" and "sphere"
+  int color_switch_;       // which coloring algorithm to use
+  int keep_going_;         // Allow to draw same configuration in loop
+  boundary_type boundary_; // boundary type to draw. currently supports
+                           // "box" and "sphere"
 
- public:
+public:
   void Init(std::vector<graph_struct *> *const graph_array,
             space_struct *s_struct, double background, int draw_boundary,
-            int auto_graph);  // Init. Must always be called.
+            int auto_graph, double alpha = 1.); // Init. Must always be called.
   void Clear();
 
   void DrawLoop();
   void Draw();
-  void SetBoundaryType(
-      std::string boundary_type);  // Set the boundary type to draw
+  void
+  SetBoundaryType(std::string boundary_type); // Set the boundary type to draw
 
- private:
+private:
   void InitColormap();
   void InitDiscoRectangle();
   void InitSpheroCylinder();
@@ -116,20 +116,19 @@ class Graphics {
   void Init3dWindow();
   void InitText();
   void KeyInteraction();
-  void DrawBox();     // Wrapper for rectangular boundaries
-  void DrawSquare();  // boundary square
-  void DrawCube();    // boundary cube
-  void DrawWireSphere(
-      double r, int lats,
-      int longs);  // Slow, not for mass drawing, just for boundary
+  void DrawBox();    // Wrapper for rectangular boundaries
+  void DrawSquare(); // boundary square
+  void DrawCube();   // boundary cube
+  void
+  DrawWireSphere(double r, int lats,
+                 int longs); // Slow, not for mass drawing, just for boundary
   void DrawBoundary();
   void DrawBudding();
-  void Draw2dBudding();  // Draws budding boundary
-  void Draw3dBudding();  // Draws budding boundary
-  void DrawSpheros();    // draw spherocylinders (3d)
-  void
-  DrawDiscorectangles();  // draw solid discorectangles (2d spherocylinders)
-  void UpdateWindow();    // update window parameters in case of resize
+  void Draw2dBudding();       // Draws budding boundary
+  void Draw3dBudding();       // Draws budding boundary
+  void DrawSpheros();         // draw spherocylinders (3d)
+  void DrawDiscorectangles(); // draw solid discorectangles (2d spherocylinders)
+  void UpdateWindow();        // update window parameters in case of resize
   void Draw2d();
   void Draw3d();
   void DrawText();

--- a/include/cglass/interaction_manager.hpp
+++ b/include/cglass/interaction_manager.hpp
@@ -6,6 +6,7 @@
 #include "cell_list.hpp"
 #include "crosslink_manager.hpp"
 #include "minimum_distance.hpp"
+#include "optical_trap_manager.hpp"
 #include "potential_manager.hpp"
 #include "species.hpp"
 #include "struct_analysis.hpp"
@@ -13,7 +14,7 @@
 typedef std::vector<Interaction>::iterator ix_iterator;
 
 class InteractionManager {
- private:
+private:
   double stress_[9];
   double dr_update_;
   bool overlap_;
@@ -45,6 +46,7 @@ class InteractionManager {
   CellList clist_;
   PotentialManager potentials_;
   CrosslinkManager xlink_;
+  OpticalTrapManager otrap_;
 
   const bool CheckSpeciesInteractorUpdate() const;
   void CheckUpdateXlinks();
@@ -69,7 +71,7 @@ class InteractionManager {
   void ApplyInteractions();
   void CalculateInteractions();
 
- public:
+public:
   InteractionManager() {}
   void Init(system_parameters *params, std::vector<SpeciesBase *> *species,
             space_struct *space, bool processing = false);
@@ -94,9 +96,12 @@ class InteractionManager {
   void ResetCellList();
   void InitCrosslinkSpecies(sid_label &slab, ParamsParser &parser,
                             unsigned long seed);
+  void InitOpticalTrapSpecies(sid_label &slab, ParamsParser &parser,
+                              unsigned long seed);
+  void InsertCrosslinks();
+  void InsertOpticalTraps(std::vector<SpeciesBase *> *species);
   void LoadCrosslinksFromCheckpoints(std::string run_name,
                                      std::string checkpoint_run_name);
-  void InsertCrosslinks();
   void SetInteractionAnalysis(bool set) { run_interaction_analysis_ = set; }
 };
 

--- a/include/cglass/optical_trap.hpp
+++ b/include/cglass/optical_trap.hpp
@@ -1,0 +1,29 @@
+/**
+ * @author      : Adam Lamson (adam.lamson@colorado.edu)
+ * @file        : optical_trap
+ * @created     : Friday Jul 03, 2020 14:49:10 MDT
+ */
+
+#ifndef OPTICAL_TRAP_HPP
+
+#define OPTICAL_TRAP_HPP
+
+#include "anchor.hpp"
+
+class OpticalTrap : public Object {
+private:
+  optical_trap_parameters *sparams_;
+  double trap_spring_;
+
+  double bead_diameter_;
+  double bead_color_;
+
+public:
+  OpticalTrap(unsigned long seed);
+  void Init(optical_trap_parameters *sparams);
+
+  //virtual ~optical_trap();
+};
+
+#endif /* end of include guard OPTICAL_TRAP_HPP */
+

--- a/include/cglass/optical_trap.hpp
+++ b/include/cglass/optical_trap.hpp
@@ -35,6 +35,8 @@ public:
   void InsertAndAttach(Object *obj);
   void AttachObjRelLambda(double lambda);
   void ApplyOpticalTrapForce();
+  void CalculateOpticalTrapForce();
+  void UpdateBeadPosition();
   double const GetMeshLambda() { return mesh_lambda_; };
   double const GetBondLambda() { return bond_lambda_; };
   void Draw(std::vector<graph_struct *> &graph_array);

--- a/include/cglass/optical_trap.hpp
+++ b/include/cglass/optical_trap.hpp
@@ -21,7 +21,8 @@ private:
 public:
   OpticalTrap(unsigned long seed);
   void Init(optical_trap_parameters *sparams);
-
+  void InsertAndAttach(Object *obj);
+  //void GetInteractors(std::vector<Object *> &ixors);
   //virtual ~optical_trap();
 };
 

--- a/include/cglass/optical_trap.hpp
+++ b/include/cglass/optical_trap.hpp
@@ -8,20 +8,36 @@
 
 #define OPTICAL_TRAP_HPP
 
-#include "anchor.hpp"
+#include "mesh.hpp"
 
 class OpticalTrap : public Object {
 private:
   optical_trap_parameters *sparams_;
+
+  Object *attach_obj_;
+
+  Bond *bond_ = nullptr;
+  double bond_length_ = -1;
+  double bond_lambda_ = -1;
+
+  Mesh *mesh_ = nullptr;
+  int mesh_n_bonds_ = -1;
+  double mesh_length_ = -1;
+  double mesh_lambda_ = -1;
+
   double trap_spring_;
 
-  double bead_diameter_;
-  double bead_color_;
+  Object bead_; //Purely for graphing right now
 
 public:
   OpticalTrap(unsigned long seed);
   void Init(optical_trap_parameters *sparams);
   void InsertAndAttach(Object *obj);
+  void AttachObjRelLambda(double lambda);
+  void ApplyOpticalTrapForce();
+  double const GetMeshLambda() { return mesh_lambda_; };
+  double const GetBondLambda() { return bond_lambda_; };
+  void Draw(std::vector<graph_struct *> &graph_array);
   //void GetInteractors(std::vector<Object *> &ixors);
   //virtual ~optical_trap();
 };

--- a/include/cglass/optical_trap_manager.hpp
+++ b/include/cglass/optical_trap_manager.hpp
@@ -1,0 +1,36 @@
+/**
+ * @author      : adamlamson (adamlamson@LamsonMacbookPro)
+ * @file        : optical_trap_manager
+ * @created     : Tuesday Jul 07, 2020 11:22:58 MDT
+ */
+
+#ifndef _CGLASS_OPTICAL_TRAP_MANAGER_HPP_
+
+#define _CGLASS_OPTICAL_TRAP_MANAGER_HPP_
+
+#include "output_manager.hpp"
+#include "species_factory.hpp"
+
+class OpticalTrapOutputManager : public OutputManagerBase<OpticalTrapSpecies> {
+  /* Do not write thermo - base output manager will handle that */
+  void WriteThermo() {}
+  void ReadThermo() {}
+  void InitThermo(std::string fname) {}
+};
+
+class OpticalTrapManager {
+private:
+  /* private data */
+  system_parameters *params_;
+  OpticalTrapOutputManager output_mgr_;
+  std::vector<Object *> *objs_;
+  space_struct *space_;
+  bool update_;
+
+public:
+  void Init(system_parameters *params, space_struct *space,
+            std::vector<Object *> *objs);
+};
+
+#endif
+

--- a/include/cglass/optical_trap_manager.hpp
+++ b/include/cglass/optical_trap_manager.hpp
@@ -23,13 +23,20 @@ private:
   /* private data */
   system_parameters *params_;
   OpticalTrapOutputManager output_mgr_;
-  std::vector<Object *> *objs_;
+  std::vector<OpticalTrapSpecies *> otrap_species_;
   space_struct *space_;
+
   bool update_;
 
 public:
-  void Init(system_parameters *params, space_struct *space,
-            std::vector<Object *> *objs);
+  void Init(system_parameters *params, space_struct *space);
+
+  void InitSpecies(sid_label &slab, ParamsParser &parser, unsigned long seed);
+
+  void InsertOpticalTraps(std::vector<SpeciesBase *> *species);
+  void UpdateOpticalTraps();
+  void Draw(std::vector<graph_struct *> &graph_array);
+  //void GetInteractors(std::vector<Object *> &ixors);
 };
 
 #endif

--- a/include/cglass/optical_trap_manager.hpp
+++ b/include/cglass/optical_trap_manager.hpp
@@ -36,6 +36,10 @@ public:
   void InsertOpticalTraps(std::vector<SpeciesBase *> *species);
   void UpdateOpticalTraps();
   void Draw(std::vector<graph_struct *> &graph_array);
+  void InitOutputs(bool reading_inputs = false,
+                   run_options *run_opts = nullptr);
+  void ReadInputs();
+  void WriteOutputs();
   //void GetInteractors(std::vector<Object *> &ixors);
 };
 

--- a/include/cglass/optical_trap_species.hpp
+++ b/include/cglass/optical_trap_species.hpp
@@ -13,12 +13,14 @@
 
 class OpticalTrapSpecies
     : public Species<OpticalTrap, species_id::optical_trap> {
+private:
+  /* private data */
+  std::string attach_species_;
+
 public:
   OpticalTrapSpecies(unsigned long seed);
   void Init(std::string spec_name, ParamsParser &parser);
-
-private:
-  /* private data */
+  void InsertOpticalTraps(std::vector<SpeciesBase *> *species);
 };
 
 #endif

--- a/include/cglass/optical_trap_species.hpp
+++ b/include/cglass/optical_trap_species.hpp
@@ -1,0 +1,25 @@
+/**
+ * @author      : adamlamson (adamlamson@LamsonMacbookPro)
+ * @file        : optical_trap_species
+ * @created     : Tuesday Jul 07, 2020 09:43:46 MDT
+ */
+
+#ifndef _CGLASS_OPTICAL_TRAP_SPECIES_HPP_
+
+#define _CGLASS_OPTICAL_TRAP_SPECIES_HPP_
+
+#include "optical_trap.hpp"
+#include "species.hpp"
+
+class OpticalTrapSpecies
+    : public Species<OpticalTrap, species_id::optical_trap> {
+public:
+  OpticalTrapSpecies(unsigned long seed);
+  void Init(std::string spec_name, ParamsParser &parser);
+
+private:
+  /* private data */
+};
+
+#endif
+

--- a/include/cglass/optical_trap_species.hpp
+++ b/include/cglass/optical_trap_species.hpp
@@ -21,6 +21,7 @@ public:
   OpticalTrapSpecies(unsigned long seed);
   void Init(std::string spec_name, ParamsParser &parser);
   void InsertOpticalTraps(std::vector<SpeciesBase *> *species);
+  void ApplyOpticalTrapForces();
 };
 
 #endif

--- a/include/cglass/output_manager.hpp
+++ b/include/cglass/output_manager.hpp
@@ -4,7 +4,8 @@
 #include "parse_flags.hpp"
 #include "species.hpp"
 
-template <class T> class OutputManagerBase {
+template <class T>
+class OutputManagerBase {
 private:
   bool posit_flag_ = false;
   bool spec_flag_ = false;
@@ -109,53 +110,60 @@ void OutputManagerBase<T>::Init(system_parameters *params,
   }
 }
 
-template <class T> void OutputManagerBase<T>::WriteOutputs() {
+template <class T>
+void OutputManagerBase<T>::WriteOutputs() {
   if (posit_flag_ && (params_->i_step % n_posit_ == 0)) {
     WritePosits();
   }
-  if (spec_flag_ && params_->i_step != params_->prev_step && (params_->i_step % n_spec_ == 0)) {
+  if (spec_flag_ && params_->i_step != params_->prev_step &&
+      (params_->i_step % n_spec_ == 0)) {
     Logger::Debug("Writing spec files");
     WriteSpecs();
   }
-  if (checkpoint_flag_ && params_->i_step != params_->prev_step && (params_->i_step % n_checkpoint_ == 0)) {
+  if (checkpoint_flag_ && params_->i_step != params_->prev_step &&
+      (params_->i_step % n_checkpoint_ == 0)) {
     Logger::Debug("Writing checkpoint files");
     WriteCheckpoints();
   }
-  if (thermo_flag_ && params_->i_step != params_->prev_step && (params_->i_step % n_thermo_ == 0)) {
+  if (thermo_flag_ && params_->i_step != params_->prev_step &&
+      (params_->i_step % n_thermo_ == 0)) {
     Logger::Debug("Writing thermo file");
     WriteThermo();
   }
 }
 
-template <class T> void OutputManagerBase<T>::WritePosits() {
+template <class T>
+void OutputManagerBase<T>::WritePosits() {
   for (auto spec = species_->begin(); spec != species_->end(); ++spec) {
-    if ((*spec)->GetPositFlag() &&
-        params_->i_step != params_->prev_step &&
+    if ((*spec)->GetPositFlag() && params_->i_step != params_->prev_step &&
         params_->i_step % (*spec)->GetNPosit() == 0) {
       (*spec)->WritePosits();
     }
   }
 }
 
-template <class T> void OutputManagerBase<T>::WriteSpecs() {
+template <class T>
+void OutputManagerBase<T>::WriteSpecs() {
   for (auto spec = species_->begin(); spec != species_->end(); ++spec) {
-    if ((*spec)->GetSpecFlag() && params_->i_step != params_->prev_step && params_->i_step % (*spec)->GetNSpec() == 0) {
+    if ((*spec)->GetSpecFlag() && params_->i_step != params_->prev_step &&
+        params_->i_step % (*spec)->GetNSpec() == 0) {
       (*spec)->WriteSpecs();
     }
   }
 }
 
-template <class T> void OutputManagerBase<T>::WriteCheckpoints() {
+template <class T>
+void OutputManagerBase<T>::WriteCheckpoints() {
   for (auto spec = species_->begin(); spec != species_->end(); ++spec) {
-    if ((*spec)->GetCheckpointFlag() &&
-        params_->i_step != params_->prev_step &&
+    if ((*spec)->GetCheckpointFlag() && params_->i_step != params_->prev_step &&
         params_->i_step % (*spec)->GetNCheckpoint() == 0) {
       (*spec)->WriteCheckpoints();
     }
   }
 }
 
-template <class T> void OutputManagerBase<T>::InitThermo(std::string fname) {
+template <class T>
+void OutputManagerBase<T>::InitThermo(std::string fname) {
   fname.append(".thermo");
   othermo_file_.open(fname, std::ios::out | std::ios::binary);
   if (!othermo_file_.is_open()) {
@@ -169,7 +177,8 @@ template <class T> void OutputManagerBase<T>::InitThermo(std::string fname) {
   othermo_file_.write(reinterpret_cast<char *>(&(params_->n_dim)), sizeof(int));
 }
 
-template <class T> void OutputManagerBase<T>::WriteThermo() {
+template <class T>
+void OutputManagerBase<T>::WriteThermo() {
   for (int i = 0; i < 9; ++i) {
     othermo_file_.write(reinterpret_cast<char *>(&(space_->unit_cell[i])),
                         sizeof(double));
@@ -184,7 +193,8 @@ template <class T> void OutputManagerBase<T>::WriteThermo() {
                       sizeof(double));
 }
 
-template <class T> void OutputManagerBase<T>::ReadThermo() {
+template <class T>
+void OutputManagerBase<T>::ReadThermo() {
   for (int i = 0; i < 9; ++i) {
     ithermo_file_.read(reinterpret_cast<char *>(&(space_->unit_cell[i])),
                        sizeof(double));
@@ -199,7 +209,8 @@ template <class T> void OutputManagerBase<T>::ReadThermo() {
                      sizeof(double));
 }
 
-template <class T> void OutputManagerBase<T>::ReadInputs() {
+template <class T>
+void OutputManagerBase<T>::ReadInputs() {
   // if ( params_->i_step % n_posit_ != 0 && params_->i_step % n_spec_ != 0) {
   // return;
   //}
@@ -212,16 +223,15 @@ template <class T> void OutputManagerBase<T>::ReadInputs() {
     // In the case that we only want to consider posits, but we only have spec
     // files, use specs to read average positions
     else if (posits_only_ && !(*spec)->GetPositFlag() &&
-             (*spec)->GetSpecFlag() &&
-             params_->i_step != params_->prev_step &&
+             (*spec)->GetSpecFlag() && params_->i_step != params_->prev_step &&
              params_->i_step % (*spec)->GetNSpec() == 0) {
       (*spec)->ReadPositsFromSpecs();
     } else if (!posits_only_ && (*spec)->GetSpecFlag() &&
-             params_->i_step != params_->prev_step &&
+               params_->i_step != params_->prev_step &&
                params_->i_step % (*spec)->GetNSpec() == 0) {
       (*spec)->ReadSpecs();
-      if (params_->checkpoint_from_spec && params_->i_step %
-          (*spec)->GetNCheckpoint() == 0 &&
+      if (params_->checkpoint_from_spec &&
+          params_->i_step % (*spec)->GetNCheckpoint() == 0 &&
           params_->i_step != params_->prev_step) {
         (*spec)->WriteCheckpoints();
       }
@@ -235,10 +245,10 @@ template <class T> void OutputManagerBase<T>::ReadInputs() {
   }
 }
 
-template <class T> void OutputManagerBase<T>::WriteReduce() {
+template <class T>
+void OutputManagerBase<T>::WriteReduce() {
   for (auto spec = species_->begin(); spec != species_->end(); ++spec) {
-    if ((*spec)->GetPositFlag() &&
-        params_->i_step != params_->prev_step &&
+    if ((*spec)->GetPositFlag() && params_->i_step != params_->prev_step &&
         params_->i_step % (reduce_factor_ * (*spec)->GetNPosit()) == 0) {
       (*spec)->WritePosits();
     }
@@ -248,12 +258,14 @@ template <class T> void OutputManagerBase<T>::WriteReduce() {
       (*spec)->WriteSpecs();
     }
   }
-  if (thermo_flag_ && params_->i_step != params_->prev_step && params_->i_step % (reduce_factor_ * n_thermo_) == 0) {
+  if (thermo_flag_ && params_->i_step != params_->prev_step &&
+      params_->i_step % (reduce_factor_ * n_thermo_) == 0) {
     WriteThermo();
   }
 }
 
-template <class T> void OutputManagerBase<T>::Close() {
+template <class T>
+void OutputManagerBase<T>::Close() {
   for (auto spec = species_->begin(); spec != species_->end(); ++spec) {
     (*spec)->CloseFiles();
   }
@@ -268,7 +280,8 @@ template <class T> void OutputManagerBase<T>::Close() {
   }
 }
 
-template <class T> void OutputManagerBase<T>::WriteTime() {
+template <class T>
+void OutputManagerBase<T>::WriteTime() {
   std::string fname = run_name_;
   fname.append(".time");
   time_file_.open(fname, std::ios::out);

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -219,6 +219,7 @@ struct system_parameters {
   bool graph_flag = false;
   int n_graph = 1000;
   double graph_diameter = 0;
+  double object_opacity = 1;
   bool invert_background = false;
   bool draw_boundary = true;
   bool load_checkpoint = false;

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -189,6 +189,18 @@ struct species_parameters<species_id::crosslink>
 };
 typedef species_parameters<species_id::crosslink> crosslink_parameters;
 
+template <>
+struct species_parameters<species_id::optical_trap>
+    : public species_base_parameters {
+  double trap_spring = 1;
+  std::string attach_species = "filament";
+  double trap_diameter = 4;
+  double bead_diameter = 2;
+  double trap_color = 3.1416;
+  double bead_color = 1.5708;
+};
+typedef species_parameters<species_id::optical_trap> optical_trap_parameters;
+
 struct system_parameters {
   long seed = 7859459105545;
   int n_runs = 1;

--- a/include/cglass/params_parser.hpp
+++ b/include/cglass/params_parser.hpp
@@ -16,6 +16,7 @@ private:
   std::vector<species_base_parameters *> species_params_;
   int n_species_ = 0;
   int n_crosslinks_ = 0;
+  int n_optical_traps_ = 0;
 
 public:
   void Init(YAML::Node sim_params);
@@ -24,6 +25,7 @@ public:
   species_base_parameters *GetNewSpeciesParameters(species_id sid,
                                                    std::string spec_name);
   const int GetNCrosslinkSpecies() { return n_crosslinks_; }
+  const int GetNOpticalTrapSpecies() { return n_optical_traps_; }
   const int GetNSpecies() { return n_species_; }
 };
 

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -46,6 +46,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.n_graph = it->second.as<int>();
     } else if (param_name.compare("graph_diameter")==0) {
     params.graph_diameter = it->second.as<double>();
+    } else if (param_name.compare("object_opacity")==0) {
+    params.object_opacity = it->second.as<double>();
     } else if (param_name.compare("invert_background")==0) {
     params.invert_background = it->second.as<bool>();
     } else if (param_name.compare("draw_boundary")==0) {

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -696,6 +696,55 @@ species_base_parameters *parse_species_params(std::string sid,
       }
     }
     return new crosslink_parameters(params);
+  } else if (sid.compare("optical_trap") == 0) {
+    optical_trap_parameters params;
+    parse_species_base_params(params, node);
+    for (auto jt = subnode.begin(); jt != subnode.end(); ++jt) {
+      std::string param_name = jt->first.as<std::string>();
+      if (false) {
+      } else if (param_name.compare("name")==0) {
+      params.name = jt->second.as<std::string>();
+      } else if (param_name.compare("num")==0) {
+      params.num = jt->second.as<int>();
+      } else if (param_name.compare("diameter")==0) {
+      params.diameter = jt->second.as<double>();
+      } else if (param_name.compare("length")==0) {
+      params.length = jt->second.as<double>();
+      } else if (param_name.compare("insertion_type")==0) {
+      params.insertion_type = jt->second.as<std::string>();
+      } else if (param_name.compare("insert_file")==0) {
+      params.insert_file = jt->second.as<std::string>();
+      } else if (param_name.compare("overlap")==0) {
+      params.overlap = jt->second.as<bool>();
+      } else if (param_name.compare("draw_type")==0) {
+      params.draw_type = jt->second.as<std::string>();
+      } else if (param_name.compare("color")==0) {
+      params.color = jt->second.as<double>();
+      } else if (param_name.compare("posit_flag")==0) {
+      params.posit_flag = jt->second.as<bool>();
+      } else if (param_name.compare("spec_flag")==0) {
+      params.spec_flag = jt->second.as<bool>();
+      } else if (param_name.compare("n_posit")==0) {
+      params.n_posit = jt->second.as<int>();
+      } else if (param_name.compare("n_spec")==0) {
+      params.n_spec = jt->second.as<int>();
+      } else if (param_name.compare("trap_spring")==0) {
+      params.trap_spring = jt->second.as<double>();
+      } else if (param_name.compare("attach_species")==0) {
+      params.attach_species = jt->second.as<std::string>();
+      } else if (param_name.compare("trap_diameter")==0) {
+      params.trap_diameter = jt->second.as<double>();
+      } else if (param_name.compare("bead_diameter")==0) {
+      params.bead_diameter = jt->second.as<double>();
+      } else if (param_name.compare("trap_color")==0) {
+      params.trap_color = jt->second.as<double>();
+      } else if (param_name.compare("bead_color")==0) {
+      params.bead_color = jt->second.as<double>();
+      } else {
+        Logger::Warning("Unrecognized %s parameter: '%s'", sid.c_str(), param_name.c_str());
+      }
+    }
+    return new optical_trap_parameters(params);
   } else {
     Logger::Error("Unrecognized SID '%s' in parse_params!", sid.c_str());
   }

--- a/include/cglass/species.hpp
+++ b/include/cglass/species.hpp
@@ -8,7 +8,8 @@
 #endif
 #include "analysis.hpp"
 
-template <typename T, unsigned char S> class Species : public SpeciesBase {
+template <typename T, unsigned char S>
+class Species : public SpeciesBase {
 protected:
   std::vector<T> members_;
   species_parameters<S> sparams_;
@@ -69,6 +70,13 @@ public:
   virtual void ReadCheckpoints();
   virtual void ScalePositions();
   virtual const std::vector<T> &GetMembers() { return members_; }
+  /* XXX: Dangerous. This need to grab members from species_base ptr. 
+   *    If there is a better way, please let me know. <14-07-20, ARL> */
+  virtual void GetMemberPtrs(std::vector<Object *> &objs) {
+    for (auto &obj : members_) {
+      objs.push_back(&obj);
+    }
+  }
   virtual void CleanUp();
   virtual void Reserve();
   virtual double const GetVolume();
@@ -103,7 +111,8 @@ public:
   }
 };
 
-template <typename T, unsigned char S> double const Species<T, S>::GetVolume() {
+template <typename T, unsigned char S>
+double const Species<T, S>::GetVolume() {
   double vol = 0.0;
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     vol += it->GetVolume();
@@ -111,13 +120,15 @@ template <typename T, unsigned char S> double const Species<T, S>::GetVolume() {
   return vol;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::Reserve() {
+template <typename T, unsigned char S>
+void Species<T, S>::Reserve() {
   members_.reserve(GetNInsert());
   Logger::Debug("Reserving memory for %d members in %s %s", GetNInsert(),
                 GetSID()._to_string(), GetSpeciesName().c_str());
 }
 
-template <typename T, unsigned char S> void Species<T, S>::AddMember() {
+template <typename T, unsigned char S>
+void Species<T, S>::AddMember() {
   T newmember(rng_.GetSeed());
   Logger::Trace("Adding member to %s %s, member number %d, member id %d",
                 GetSID()._to_string(), GetSpeciesName().c_str(), n_members_ + 1,
@@ -128,7 +139,8 @@ template <typename T, unsigned char S> void Species<T, S>::AddMember() {
   n_members_++;
 }
 
-template <typename T, unsigned char S> double const Species<T, S>::GetDrMax() {
+template <typename T, unsigned char S>
+double const Species<T, S>::GetDrMax() {
   double max_dr = 0;
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     double dr = it->GetDrTot();
@@ -145,7 +157,8 @@ template <typename T, unsigned char S> double const Species<T, S>::GetDrMax() {
   return max_dr;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ZeroDrTot() {
+template <typename T, unsigned char S>
+void Species<T, S>::ZeroDrTot() {
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     it->ZeroDrTot();
   }
@@ -160,7 +173,8 @@ void Species<T, S>::ResetPreviousPositions() {
   }
 }
 
-template <typename T, unsigned char S> void Species<T, S>::AddMember(T newmem) {
+template <typename T, unsigned char S>
+void Species<T, S>::AddMember(T newmem) {
   Logger::Trace("Adding preexisting member to %s %s", GetSID()._to_string(),
                 GetSpeciesName().c_str());
   members_.push_back(newmem);
@@ -168,7 +182,8 @@ template <typename T, unsigned char S> void Species<T, S>::AddMember(T newmem) {
   n_members_++;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::PopMember() {
+template <typename T, unsigned char S>
+void Species<T, S>::PopMember() {
   Logger::Trace("Removing last member of %s %s", GetSID()._to_string(),
                 GetSpeciesName().c_str());
   members_.back().Cleanup();
@@ -176,7 +191,8 @@ template <typename T, unsigned char S> void Species<T, S>::PopMember() {
   n_members_--;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::PopAll() {
+template <typename T, unsigned char S>
+void Species<T, S>::PopAll() {
   while (n_members_ > 0) {
     PopMember();
   }
@@ -192,7 +208,8 @@ void Species<T, S>::Draw(std::vector<graph_struct *> &graph_array) {
   }
 }
 
-template <typename T, unsigned char S> void Species<T, S>::UpdatePositions() {
+template <typename T, unsigned char S>
+void Species<T, S>::UpdatePositions() {
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     it->UpdatePosition();
   }
@@ -227,19 +244,22 @@ double Species<T, S>::GetPotentialEnergy() {
   return 0.5 * pe;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ZeroForces() {
+template <typename T, unsigned char S>
+void Species<T, S>::ZeroForces() {
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     it->ZeroForce();
   }
 }
 
-template <typename T, unsigned char S> void Species<T, S>::Report() {
+template <typename T, unsigned char S>
+void Species<T, S>::Report() {
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     it->Report();
   }
 }
 
-template <typename T, unsigned char S> int Species<T, S>::GetCount() {
+template <typename T, unsigned char S>
+int Species<T, S>::GetCount() {
   int count = 0;
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     count += it->GetCount();
@@ -247,21 +267,24 @@ template <typename T, unsigned char S> int Species<T, S>::GetCount() {
   return count;
 }
 
-template <typename T, unsigned char S> void Species<T, S>::WritePosits() {
+template <typename T, unsigned char S>
+void Species<T, S>::WritePosits() {
   int size = members_.size();
   oposit_file_.write(reinterpret_cast<char *>(&size), sizeof(int));
   for (auto it = members_.begin(); it != members_.end(); ++it)
     it->WritePosit(oposit_file_);
 }
 
-template <typename T, unsigned char S> void Species<T, S>::WriteSpecs() {
+template <typename T, unsigned char S>
+void Species<T, S>::WriteSpecs() {
   int size = members_.size();
   ospec_file_.write(reinterpret_cast<char *>(&size), sizeof(int));
   for (auto it = members_.begin(); it != members_.end(); ++it)
     it->WriteSpec(ospec_file_);
 }
 
-template <typename T, unsigned char S> void Species<T, S>::WriteCheckpoints() {
+template <typename T, unsigned char S>
+void Species<T, S>::WriteCheckpoints() {
   Logger::Trace("Writing checkpoints for %s %s", GetSID()._to_string(),
                 GetSpeciesName().c_str());
   std::fstream ocheck_file(checkpoint_file_, std::ios::out | std::ios::binary);
@@ -283,7 +306,8 @@ template <typename T, unsigned char S> void Species<T, S>::WriteCheckpoints() {
   ocheck_file.close();
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ReadPosits() {
+template <typename T, unsigned char S>
+void Species<T, S>::ReadPosits() {
   if (iposit_file_.eof()) {
     Logger::Info("EOF reached while reading posits");
     early_exit = true;
@@ -319,7 +343,8 @@ void Species<T, S>::ReadPositsFromSpecs() {
   }
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ReadCheckpoints() {
+template <typename T, unsigned char S>
+void Species<T, S>::ReadCheckpoints() {
   Logger::Trace("Reading checkpoints for %s %s", GetSID()._to_string(),
                 GetSpeciesName().c_str());
   std::fstream icheck_file(checkpoint_file_, std::ios::in | std::ios::binary);
@@ -349,7 +374,8 @@ template <typename T, unsigned char S> void Species<T, S>::ReadCheckpoints() {
   Object::SetNextOID(next_oid);
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ReadSpecs() {
+template <typename T, unsigned char S>
+void Species<T, S>::ReadSpecs() {
   if (ispec_file_.eof()) {
     if (HandleEOF()) {
       return;
@@ -389,16 +415,19 @@ template <typename T, unsigned char S> void Species<T, S>::ReadSpecs() {
     it->ReadSpec(ispec_file_);
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ScalePositions() {
+template <typename T, unsigned char S>
+void Species<T, S>::ScalePositions() {
   for (auto it = members_.begin(); it != members_.end(); ++it)
     it->ScalePosition();
 }
 
-template <typename T, unsigned char S> void Species<T, S>::CleanUp() {
+template <typename T, unsigned char S>
+void Species<T, S>::CleanUp() {
   members_.clear();
 }
 
-template <typename T, unsigned char S> void Species<T, S>::ArrangeMembers() {
+template <typename T, unsigned char S>
+void Species<T, S>::ArrangeMembers() {
   if (GetInsertionType().compare("custom") == 0)
     CustomInsert();
   else if (GetInsertionType().compare("simple_crystal") == 0)
@@ -444,10 +473,10 @@ void Species<T, S>::CrystalArrangement() {
   double nZ_max = (n_dim == 3 ? nX_max : 1);
   double N = nX_max * nY_max * nZ_max;
   if (n_members_ > N) {
-    Logger::Error(
-        "Number of members in species exceeds maximum possible for crystal in "
-        "system radius! Max possible: %d",
-        (int)N);
+    Logger::Error("Number of members in species exceeds maximum possible for "
+                  "crystal in "
+                  "system radius! Max possible: %d",
+                  (int)N);
   }
   double fraction = N / n_members_;
   if (fraction < 1)
@@ -525,7 +554,8 @@ void Species<T, S>::CrystalArrangement() {
   }
 }
 
-template <typename T, unsigned char S> void Species<T, S>::CustomInsert() {
+template <typename T, unsigned char S>
+void Species<T, S>::CustomInsert() {
   YAML::Node inode;
   std::string spec_name = GetSID()._to_string();
   try {

--- a/include/cglass/species_base.hpp
+++ b/include/cglass/species_base.hpp
@@ -36,6 +36,7 @@ public:
   virtual double GetPotentialEnergy() { return 0; }
   virtual void ScalePositions() {}
   virtual void AddMember() {}
+  virtual void GetMemberPtrs(std::vector<Object *> &objs) {}
   virtual void SetLastMemberPosition(double const *const pos) {}
   virtual void ResetPreviousPositions() {}
   virtual void PopMember() {}

--- a/include/cglass/species_factory.hpp
+++ b/include/cglass/species_factory.hpp
@@ -4,13 +4,14 @@
 #include "br_bead_species.hpp"
 #include "crosslink_species.hpp"
 #include "filament_species.hpp"
+#include "optical_trap_species.hpp"
 #include "rigid_filament_species.hpp"
 #include "spherocylinder_species.hpp"
 #include "spindle_species.hpp"
 
 class SpeciesFactory {
- public:
-  SpeciesBase* CreateSpecies(const species_id sid, unsigned long seed) const {
+public:
+  SpeciesBase *CreateSpecies(const species_id sid, unsigned long seed) const {
     if (sid == +species_id::filament) {
       return new FilamentSpecies(seed);
     } else if (sid == +species_id::rigid_filament) {
@@ -23,6 +24,8 @@ class SpeciesFactory {
       return new SpindleSpecies(seed);
     } else if (sid == +species_id::spherocylinder) {
       return new SpherocylinderSpecies(seed);
+    } else if (sid == +species_id::optical_trap) {
+      return new OpticalTrapSpecies(seed);
     }
     Logger::Error("Species ID not recognized in SpeciesFactory!");
     return nullptr;

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -29,7 +29,6 @@ void CrosslinkSpecies::InitInteractionEnvironment(std::vector<Object *> *objs,
   lut_ = LookupTable(lut_filler_ptr);
   if (sparams_.use_binding_volume)
     lut_.setBindVol(lut_filler_ptr->getBindingVolume());
-  /* TODO: Add time testing right here <24-06-20, ARL> */
   TestKMCStepSize();
   delete lut_filler_ptr;
 }
@@ -39,7 +38,6 @@ void CrosslinkSpecies::InitInteractionEnvironment(std::vector<Object *> *objs,
  * \return void, will end program if dt is too high.
  */
 void CrosslinkSpecies::TestKMCStepSize() {
-  /* TODO: Make this acceptable for C-GLASS <24-06-20, ARL> */
   KMC<int> kmc_diag(params_->delta, &lut_);
 
   const double prob_thresh = 1e-4;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1,12 +1,12 @@
 #ifndef NOGRAPH
 
 #include "cglass/graphics.hpp"
-#include <stdarg.h>
+#include "cglass/macros.hpp"
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
-#include "cglass/macros.hpp"
+#include <stdarg.h>
 
 static void key_callback2d(GLFWwindow *window, int key, int scancode,
                            int action, int mods) {
@@ -17,56 +17,59 @@ static void key_callback2d(GLFWwindow *window, int key, int scancode,
 
   if (action == GLFW_PRESS) {
     switch (key) {
-      case GLFW_KEY_ESCAPE:
-        graphics->keep_going_ = 1;
-        break;
-      case GLFW_KEY_UP:
-        graphics->yTrans_ += 0.5;
-        break;
-      case GLFW_KEY_DOWN:
-        graphics->yTrans_ -= 0.5;
-        break;
-      case GLFW_KEY_RIGHT:
-        graphics->xTrans_ += 0.5;
-        break;
-      case GLFW_KEY_LEFT:
-        graphics->xTrans_ -= 0.5;
-        break;
-      case GLFW_KEY_Z:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->zAngle_ += 5.0;
-        else
-          graphics->zAngle_ -= 5.0;
-        break;
-      case GLFW_KEY_SPACE:
-        graphics->xyzScale_ += 1.0 / 10.0;
-        break;
-      case GLFW_KEY_BACKSPACE:
-        graphics->xyzScale_ -= 1.0 / 10.0;
-        break;
-      case GLFW_KEY_C:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->color_switch_ = (graphics->color_switch_ + 1) % 3;
-        else {
-          graphics->color_switch_ = (graphics->color_switch_ - 1);
-          if (graphics->color_switch_ < 0) graphics->color_switch_ = 2;
-        }
-        break;
-      case GLFW_KEY_A:
-        if (mods & GLFW_MOD_SHIFT) {
-          graphics->alpha_ += 0.1;
-          if (graphics->alpha_ > 1.0) graphics->alpha_ = 1.0;
-        } else {
-          graphics->alpha_ -= 0.1;
-          if (graphics->alpha_ < 0.0) graphics->alpha_ = 0.0;
-        }
-        break;
-      case GLFW_KEY_T:
-        // graphics->draw_trajectory_flag_ =
-        //   (graphics->draw_trajectory_flag_ + 1) % 2;
-        break;
-      default:
-        break;
+    case GLFW_KEY_ESCAPE:
+      graphics->keep_going_ = 1;
+      break;
+    case GLFW_KEY_UP:
+      graphics->yTrans_ += 0.5;
+      break;
+    case GLFW_KEY_DOWN:
+      graphics->yTrans_ -= 0.5;
+      break;
+    case GLFW_KEY_RIGHT:
+      graphics->xTrans_ += 0.5;
+      break;
+    case GLFW_KEY_LEFT:
+      graphics->xTrans_ -= 0.5;
+      break;
+    case GLFW_KEY_Z:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->zAngle_ += 5.0;
+      else
+        graphics->zAngle_ -= 5.0;
+      break;
+    case GLFW_KEY_SPACE:
+      graphics->xyzScale_ += 1.0 / 10.0;
+      break;
+    case GLFW_KEY_BACKSPACE:
+      graphics->xyzScale_ -= 1.0 / 10.0;
+      break;
+    case GLFW_KEY_C:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->color_switch_ = (graphics->color_switch_ + 1) % 3;
+      else {
+        graphics->color_switch_ = (graphics->color_switch_ - 1);
+        if (graphics->color_switch_ < 0)
+          graphics->color_switch_ = 2;
+      }
+      break;
+    case GLFW_KEY_A:
+      if (mods & GLFW_MOD_SHIFT) {
+        graphics->alpha_ += 0.1;
+        if (graphics->alpha_ > 1.0)
+          graphics->alpha_ = 1.0;
+      } else {
+        graphics->alpha_ -= 0.1;
+        if (graphics->alpha_ < 0.0)
+          graphics->alpha_ = 0.0;
+      }
+      break;
+    case GLFW_KEY_T:
+      // graphics->draw_trajectory_flag_ =
+      //   (graphics->draw_trajectory_flag_ + 1) % 2;
+      break;
+    default:
+      break;
     }
   }
 }
@@ -80,68 +83,68 @@ static void key_callback3d(GLFWwindow *window, int key, int scancode,
 
   if (action == GLFW_PRESS) {
     switch (key) {
-      case GLFW_KEY_ESCAPE:
-        graphics->keep_going_ = 1;
-        break;
-      case GLFW_KEY_UP:
-        graphics->xAngle_ += 5.0;
-        break;
-      case GLFW_KEY_DOWN:
-        graphics->xAngle_ -= 5.0;
-        break;
-      case GLFW_KEY_RIGHT:
-        graphics->yAngle_ += 5.0;
-        break;
-      case GLFW_KEY_LEFT:
-        graphics->yAngle_ -= 5.0;
-        break;
-      case GLFW_KEY_Z:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->zAngle_ -= 5.0;
-        else
-          graphics->zAngle_ += 5.0;
-        break;
-      case GLFW_KEY_C:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->cNear_ -= 0.5;
-        else
-          graphics->cNear_ += 0.5;
-        break;
-      case GLFW_KEY_V:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->cFar_ += 0.5;
-        else
-          graphics->cFar_ -= 0.5;
-        break;
-      case GLFW_KEY_J:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->cxAngle_ -= 5.0;
-        else
-          graphics->cxAngle_ += 5.0;
-        break;
-      case GLFW_KEY_K:
-        if (mods & GLFW_MOD_SHIFT)
-          graphics->cyAngle_ -= 5.0;
-        else
-          graphics->cyAngle_ += 5.0;
-        break;
-      case GLFW_KEY_SPACE:
-        graphics->xyzScale_ += 1.0 / 10.0;
-        break;
-      case GLFW_KEY_BACKSPACE:
-        graphics->xyzScale_ -= 1.0 / 10.0;
-        break;
-      case GLFW_KEY_M:
-        graphics->color_switch_ = (graphics->color_switch_ + 1) % 3;
-        break;
-      case GLFW_KEY_R:
-        graphics->xyzScale_ *= 0.5;
-        break;
-      case GLFW_KEY_T:
-        graphics->xyzScale_ *= 2.0;
-        break;
-      default:
-        break;
+    case GLFW_KEY_ESCAPE:
+      graphics->keep_going_ = 1;
+      break;
+    case GLFW_KEY_UP:
+      graphics->xAngle_ += 5.0;
+      break;
+    case GLFW_KEY_DOWN:
+      graphics->xAngle_ -= 5.0;
+      break;
+    case GLFW_KEY_RIGHT:
+      graphics->yAngle_ += 5.0;
+      break;
+    case GLFW_KEY_LEFT:
+      graphics->yAngle_ -= 5.0;
+      break;
+    case GLFW_KEY_Z:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->zAngle_ -= 5.0;
+      else
+        graphics->zAngle_ += 5.0;
+      break;
+    case GLFW_KEY_C:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->cNear_ -= 0.5;
+      else
+        graphics->cNear_ += 0.5;
+      break;
+    case GLFW_KEY_V:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->cFar_ += 0.5;
+      else
+        graphics->cFar_ -= 0.5;
+      break;
+    case GLFW_KEY_J:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->cxAngle_ -= 5.0;
+      else
+        graphics->cxAngle_ += 5.0;
+      break;
+    case GLFW_KEY_K:
+      if (mods & GLFW_MOD_SHIFT)
+        graphics->cyAngle_ -= 5.0;
+      else
+        graphics->cyAngle_ += 5.0;
+      break;
+    case GLFW_KEY_SPACE:
+      graphics->xyzScale_ += 1.0 / 10.0;
+      break;
+    case GLFW_KEY_BACKSPACE:
+      graphics->xyzScale_ -= 1.0 / 10.0;
+      break;
+    case GLFW_KEY_M:
+      graphics->color_switch_ = (graphics->color_switch_ + 1) % 3;
+      break;
+    case GLFW_KEY_R:
+      graphics->xyzScale_ *= 0.5;
+      break;
+    case GLFW_KEY_T:
+      graphics->xyzScale_ *= 2.0;
+      break;
+    default:
+      break;
     }
   }
 }
@@ -153,10 +156,10 @@ void Graphics::KeyInteraction() {
   // controls
   // No key interactions if we're doing auto_graph
   //if (!auto_graph_) {
-    if (n_dim_ == 2)
-      glfwSetKeyCallback(window_, key_callback2d);
-    else if (n_dim_ == 3)
-      glfwSetKeyCallback(window_, key_callback3d);
+  if (n_dim_ == 2)
+    glfwSetKeyCallback(window_, key_callback2d);
+  else if (n_dim_ == 3)
+    glfwSetKeyCallback(window_, key_callback3d);
   //}
   // Check window for key presses/mouse interaction
   glfwPollEvents();
@@ -226,9 +229,9 @@ void Graphics::InitWindow() {
 void Graphics::Init2dWindow() {
   // Defaults for window view and coloring
   xyzScale_ = 0.95;
-  xTrans_ = yTrans_ = 0.0;  // x,y translation
-  color_switch_ = 1;        // Default 'nice' spherocylinder coloring
-  alpha_ = 1.0;             // transparency
+  xTrans_ = yTrans_ = 0.0; // x,y translation
+  color_switch_ = 1;       // Default 'nice' spherocylinder coloring
+  alpha_ = 1.0;            // transparency
 
   /* Compute size of the window respecting the aspect ratio. */
   if (unit_cell_[0] > unit_cell_[3]) {
@@ -239,9 +242,10 @@ void Graphics::Init2dWindow() {
     windx_ = (int)(windy_ * unit_cell_[0] / unit_cell_[3]);
   }
 
-  {  // Make dummy window so we can get GL extensions
+  { // Make dummy window so we can get GL extensions
     glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
-    if (!glfwInit()) Logger::Error("Unable to initialize GLFW toolkit\n");
+    if (!glfwInit())
+      Logger::Error("Unable to initialize GLFW toolkit\n");
 
     window_ = glfwCreateWindow(windx_, windy_, "2D Sphero", NULL, NULL);
 
@@ -266,8 +270,8 @@ void Graphics::Init2dWindow() {
   }
 
   glfwMakeContextCurrent(window_);
-  glfwSwapInterval(0);  // swap buffers immediately
-  glewInit();           // re-initialize glew for current window context
+  glfwSwapInterval(0); // swap buffers immediately
+  glewInit();          // re-initialize glew for current window context
 
   // Blending and antialiasing. Makes things pretty.
   glEnable(GL_LINE_SMOOTH);
@@ -295,7 +299,7 @@ void Graphics::Init2dWindow() {
       (GLdouble)(ymin - 0.05 * unit_cell_[3]),
       (GLdouble)(ymax +
                  0.05 *
-                     unit_cell_[3]));  // deprecated, but annoying to implement
+                     unit_cell_[3])); // deprecated, but annoying to implement
   /* JMM attempting to fix Mac resize issues */
   glfwGetFramebufferSize(window_, &windx_, &windy_);
   /* establish initial viewport */
@@ -306,8 +310,8 @@ void Graphics::Init3dWindow() {
   xAngle_ = 90;
   yAngle_ = 0;
   zAngle_ = 90;
-  xyzScale_ = 0.95;  // zoom out just a hair.
-  zTrans_ = -24;     // camera position in z
+  xyzScale_ = 0.95; // zoom out just a hair.
+  zTrans_ = -24;    // camera position in z
   color_switch_ = 1;
 
   // FIXME: Assumes a square box. Better way to calculate this, but we
@@ -316,15 +320,16 @@ void Graphics::Init3dWindow() {
   for (int i = 0; i < 3; ++i)
     a_perp_max = MAX(unit_cell_[3 * i + i], a_perp_max);
 
-  cNear_ = -2.0 * a_perp_max;  // clipping plane near
-  cFar_ = 2.0 * a_perp_max;    // clipping plane far
-  cxAngle_ = cyAngle_ = 0;     // plane angles
+  cNear_ = -2.0 * a_perp_max; // clipping plane near
+  cFar_ = 2.0 * a_perp_max;   // clipping plane far
+  cxAngle_ = cyAngle_ = 0;    // plane angles
 
-  windx_ = windy_ = 400;  // window size in pixels
+  windx_ = windy_ = 400; // window size in pixels
 
-  {  // Make dummy window so we can get GL extensions
+  { // Make dummy window so we can get GL extensions
     glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
-    if (!glfwInit()) Logger::Error("Unable to initialize GLFW toolkit\n");
+    if (!glfwInit())
+      Logger::Error("Unable to initialize GLFW toolkit\n");
 
     window_ = glfwCreateWindow(windx_, windy_, "2D Sphero", NULL, NULL);
 
@@ -341,7 +346,7 @@ void Graphics::Init3dWindow() {
   }
 
   // Rebuild window now that we have proper information about the GL extensions
-  glfwWindowHint(GLFW_SAMPLES, 16);  // 16x Multisampling
+  glfwWindowHint(GLFW_SAMPLES, 16); // 16x Multisampling
   window_ = glfwCreateWindow(windx_, windy_, "2D Sphero", NULL, NULL);
 
   if (!window_) {
@@ -350,8 +355,8 @@ void Graphics::Init3dWindow() {
   }
 
   glfwMakeContextCurrent(window_);
-  glfwSwapInterval(0);  // Swap buffers immediately
-  glewInit();           // Get GL extensions for current context
+  glfwSwapInterval(0); // Swap buffers immediately
+  glewInit();          // Get GL extensions for current context
 
   /* FIXME: this probably does nothing nowadays */
   /* Material properties. */
@@ -402,16 +407,16 @@ void Graphics::Init3dWindow() {
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   gluPerspective(-60.0, 1.0, 1.5 * unit_cell_[8] / 2.0,
-                 10.0 * 1.5 * unit_cell_[8] / 2.0);  // deprecated
+                 10.0 * 1.5 * unit_cell_[8] / 2.0); // deprecated
 
   /* establish initial viewport */
   glfwGetFramebufferSize(window_, &windx_, &windy_);
   glViewport(0, 0, windx_, windy_);
 }
 
-void Graphics::InitColormap() {  // Pretty straight forward. Builds
-                                 // colormap. Automatic for all instances of
-                                 // Graphics class after Init() call
+void Graphics::InitColormap() { // Pretty straight forward. Builds
+                                // colormap. Automatic for all instances of
+                                // Graphics class after Init() call
   /* Loop over colormap indices. */
   for (int i_color = 0; i_color < n_rgb_; ++i_color) {
     GLfloat red, green, blue;
@@ -449,11 +454,11 @@ void Graphics::InitColormap() {  // Pretty straight forward. Builds
 }
 
 void Graphics::DrawDiscorectangles() {
-  glMatrixMode(GL_MODELVIEW);  // Make sure we're using the model transform
+  glMatrixMode(GL_MODELVIEW); // Make sure we're using the model transform
 
   // Tells gl to use the appropriate shader for the discorectangle
-  glUseProgram(discorectangle_.program_);  // This could be moved to a
-                                           // GraphicsPrimitive method.
+  glUseProgram(discorectangle_.program_); // This could be moved to a
+                                          // GraphicsPrimitive method.
 
   // spherocylinder takes two parameters, half its length, and its diameter
   // Get location of half_l and diameter parameters, this shouldn't need to be
@@ -467,12 +472,12 @@ void Graphics::DrawDiscorectangles() {
   // Prep to send vertex data to shader
   glEnableVertexAttribArray(discorectangle_.attributes_.position);
   glBindBuffer(GL_ARRAY_BUFFER, discorectangle_.vertex_buffer_);
-  glVertexAttribPointer(discorectangle_.attributes_.position,  // attribute
-                        2,  // number of elements per vertex, here (x,y,z)
-                        GL_FLOAT,  // the type of each element
-                        GL_FALSE,  // take our values as-is
-                        0,         // no extra data between each position
-                        (void *)0  // offset of first element
+  glVertexAttribPointer(discorectangle_.attributes_.position, // attribute
+                        2,        // number of elements per vertex, here (x,y,z)
+                        GL_FLOAT, // the type of each element
+                        GL_FALSE, // take our values as-is
+                        0,        // no extra data between each position
+                        (void *)0 // offset of first element
   );
 
   // Use the element buffer (numerical pointer to each set of vertices that make
@@ -482,7 +487,7 @@ void Graphics::DrawDiscorectangles() {
   // Set default bond color
   GLfloat color[4] = {0.0, 0.0, 1.0, 1.0};
   for (auto it = graph_array_->begin(); it != graph_array_->end(); ++it) {
-    double theta = atan2((*it)->u[1], (*it)->u[0]);  // rotation angle
+    double theta = atan2((*it)->u[1], (*it)->u[0]); // rotation angle
     double theta_color = 0;
     // Check draw type
     if ((*it)->draw == +draw_type::fixed) {
@@ -511,12 +516,12 @@ void Graphics::DrawDiscorectangles() {
 
       glColor4fv(&colormap_[color_index * 4]);
     }
-    glPushMatrix();  // Duplicate current modelview
+    glPushMatrix(); // Duplicate current modelview
     {
       glTranslatef((*it)->r[0], (*it)->r[1] - z_correct_,
-                   0.0);  // Translate rod
+                   0.0); // Translate rod
       glRotatef((GLfloat)((theta / M_PI) * 180.0 - 90.0), 0.0, 0.0,
-                1.0);  // rotate rod
+                1.0); // rotate rod
 
       // Tell shader about our spherocylinder parameters
       double half_length = 0.5 * (*it)->length;
@@ -524,22 +529,22 @@ void Graphics::DrawDiscorectangles() {
       glUniform1f(discorectangle_.uniforms_.diameter, (*it)->diameter);
       glDrawElements(GL_TRIANGLES, discorectangle_.n_triangles_ * 3,
                      GL_UNSIGNED_SHORT,
-                     (void *)0);  // draw.
+                     (void *)0); // draw.
     }
-    glPopMatrix();  // restore default modelview
+    glPopMatrix(); // restore default modelview
   }
   glDisableVertexAttribArray(
       discorectangle_.attributes_
-          .position);  // Tell GL to forget about our vertex array
+          .position); // Tell GL to forget about our vertex array
 }
 
 void Graphics::Draw2d() {
   KeyInteraction();
-  UpdateWindow();  // Recalculate window parameters (in case of resize)
+  UpdateWindow(); // Recalculate window parameters (in case of resize)
   DrawDiscorectangles();
   DrawBoundary();
   // DrawText();
-  glfwSwapBuffers(window_);  // Print frame to screen
+  glfwSwapBuffers(window_); // Print frame to screen
 }
 
 // void Graphics::DrawText() {
@@ -610,7 +615,7 @@ void Graphics::Draw2d() {
 //}
 
 void Graphics::DrawSpheros() {
-  glMatrixMode(GL_MODELVIEW);  // Use modelview matrix
+  glMatrixMode(GL_MODELVIEW); // Use modelview matrix
 
   /* Don't draw back facing triangles (as they would be occluded anyway */
   glEnable(GL_CULL_FACE);
@@ -626,19 +631,19 @@ void Graphics::DrawSpheros() {
   /* Prep to send vertex data to shader */
   glEnableVertexAttribArray(spherocylinder_.attributes_.position);
   glBindBuffer(GL_ARRAY_BUFFER, spherocylinder_.vertex_buffer_);
-  glVertexAttribPointer(spherocylinder_.attributes_.position,  // attribute
-                        3,  // number of elements per vertex, here (x,y,z)
-                        GL_FLOAT,  // the type of each element
-                        GL_FALSE,  // take our values as-is
-                        0,         // no extra data between each position
-                        (void *)0  // offset of first element
+  glVertexAttribPointer(spherocylinder_.attributes_.position, // attribute
+                        3,        // number of elements per vertex, here (x,y,z)
+                        GL_FLOAT, // the type of each element
+                        GL_FALSE, // take our values as-is
+                        0,        // no extra data between each position
+                        (void *)0 // offset of first element
   );
 
   /* Use the element buffer (numerical pointer to each set of vertices that make
    * a triangle) */
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, spherocylinder_.element_buffer_);
 
-  GLfloat color[4] = {0.0, 0.0, 1.0, 1.0};  // default bond color
+  GLfloat color[4] = {0.0, 0.0, 1.0, 1.0}; // default bond color
   // for (int i_bond = 0; i_bond < n_spheros; ++i_bond) {
   for (auto it = graph_array_->begin(); it != graph_array_->end(); ++it) {
     /* Determine phi rotation angle, amount to rotate about y. */
@@ -649,7 +654,8 @@ void Graphics::DrawSpheros() {
     double length_xy = sqrt(SQR((*it)->u[0]) + SQR((*it)->u[1]));
     if (length_xy > 0.0) {
       theta = acos((*it)->u[0] / length_xy);
-      if ((*it)->u[1] < 0.0) theta = (2.0 * M_PI) - theta;
+      if ((*it)->u[1] < 0.0)
+        theta = (2.0 * M_PI) - theta;
     }
     color[3] = alpha_;
     std::string d_type((*it)->draw._to_string());
@@ -727,7 +733,8 @@ void Graphics::DrawSpheros() {
     glTranslatef(v0, v1, v2);
     if (theta != 0.0)
       glRotatef((GLfloat)((theta / M_PI) * 180.0), 0.0, 0.0, 1.0);
-    if (phi != 0.0) glRotatef((GLfloat)((phi / M_PI) * 180.0), 0.0, 1.0, 0.0);
+    if (phi != 0.0)
+      glRotatef((GLfloat)((phi / M_PI) * 180.0), 0.0, 1.0, 0.0);
 
     /* Send data to shader to be drawn */
     glDrawElements(GL_TRIANGLES, spherocylinder_.n_triangles_ * 3,
@@ -748,7 +755,8 @@ void Graphics::Draw3d() {
 }
 
 void Graphics::DrawBoundary() {
-  if (boundary_ == +boundary_type::none) return;
+  if (boundary_ == +boundary_type::none)
+    return;
   glUseProgram(0);
 
   GLfloat color[4] = {0.5, 0.5, 0.5, 1.0};
@@ -762,7 +770,8 @@ void Graphics::DrawBoundary() {
     if (n_dim_ == 2)
       // DrawWireSphere(0.5*unit_cell_[0], 3, 32);
       DrawWireSphere(0.5 * unit_cell_[0], 32, 32);
-    if (n_dim_ == 3) DrawWireSphere(0.5 * unit_cell_[0], 16, 16);
+    if (n_dim_ == 3)
+      DrawWireSphere(0.5 * unit_cell_[0], 16, 16);
 
   } else if (boundary_ == +boundary_type::box)
     DrawBox();
@@ -1215,12 +1224,11 @@ void Graphics::InitDiscoRectangle() {
   }
 
   /* Fragment shader source code */
-  const char *fs =
-      "#version 120\n"
-      "void main()"
-      "{"
-      "gl_FragColor = gl_Color;"
-      "}";
+  const char *fs = "#version 120\n"
+                   "void main()"
+                   "{"
+                   "gl_FragColor = gl_Color;"
+                   "}";
 
   discorectangle_.fragment_shader_ = glCreateShader(GL_FRAGMENT_SHADER);
   glShaderSource(discorectangle_.fragment_shader_, 1, &fs, NULL);
@@ -1445,6 +1453,8 @@ void Graphics::InitSpheroCylinder() {
       "color += att * (diffuse * NdotL + ambient);"
       "}"
       ""
+      "color[3] = .5;" //FIXME Hard coded to reduce opacity of objects.
+                       //Make this an option using snprintf.
       "gl_FragColor = color;"
       "}";
 

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -70,8 +70,10 @@ void InteractionManager::Interact() {
     return;
   // Check if we need to update objects in cell list
   CheckUpdateObjects();
-  // Update crosslinks
+  // Update crosslinks and apply forces and torques to bound objects
   xlink_.UpdateCrosslinks();
+  // Update positions and forces optical traps apply to objects
+  otrap_.UpdateOpticalTraps();
   // Check if we need to update crosslink interactors
   CheckUpdateXlinks();
   // Check if we need to update pair interactions
@@ -125,6 +127,7 @@ void InteractionManager::UpdateInteractors() {
   interactors_.insert(interactors_.end(), ix_objects_.begin(),
                       ix_objects_.end());
   std::vector<Object *> xlinks;
+  //std::vector<Object *> otraps;
   xlink_.GetInteractors(xlinks);
   interactors_.insert(interactors_.end(), xlinks.begin(), xlinks.end());
   Logger::Trace("Updated interactors: %d objects, %d crosslinks, %d total",
@@ -218,6 +221,7 @@ void InteractionManager::UpdatePairInteractions() {
   pair_interactions_.clear();
   clist_.RenewObjectsCells(interactors_);
   clist_.MakePairs(pair_interactions_);
+  /* TODO: Add optical trap pair interactions <08-07-20, ARL> */
 #ifdef TRACE
   Logger::Trace("Updated interactions: pair interactions: %d -> %d", nix,
                 pair_interactions_.size());
@@ -731,6 +735,7 @@ void InteractionManager::AddInteractors(std::vector<Object *> &ixs) {
 void InteractionManager::DrawInteractions(
     std::vector<graph_struct *> &graph_array) {
   xlink_.Draw(graph_array);
+  otrap_.Draw(graph_array);
 }
 
 void InteractionManager::WriteOutputs() { xlink_.WriteOutputs(); }
@@ -746,6 +751,16 @@ void InteractionManager::InitCrosslinkSpecies(sid_label &slab,
                                               ParamsParser &parser,
                                               unsigned long seed) {
   xlink_.InitSpecies(slab, parser, seed);
+}
+void InteractionManager::InitOpticalTrapSpecies(sid_label &slab,
+                                                ParamsParser &parser,
+                                                unsigned long seed) {
+  otrap_.InitSpecies(slab, parser, seed);
+}
+
+void InteractionManager::InsertOpticalTraps(
+    std::vector<SpeciesBase *> *species) {
+  otrap_.InsertOpticalTraps(species);
 }
 
 void InteractionManager::LoadCrosslinksFromCheckpoints(

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -23,6 +23,7 @@ void InteractionManager::Init(system_parameters *params,
   // Update dr distance should be half the cell length, and we are comparing the
   // squares of the trajectory distances
   xlink_.Init(params_, space_, &ix_objects_);
+  otrap_.Init(params_, space_);
   no_boundaries_ = false;
   if (space_->type == +boundary_type::none)
     no_boundaries_ = true;
@@ -221,7 +222,6 @@ void InteractionManager::UpdatePairInteractions() {
   pair_interactions_.clear();
   clist_.RenewObjectsCells(interactors_);
   clist_.MakePairs(pair_interactions_);
-  /* TODO: Add optical trap pair interactions <08-07-20, ARL> */
 #ifdef TRACE
   Logger::Trace("Updated interactions: pair interactions: %d -> %d", nix,
                 pair_interactions_.size());
@@ -738,14 +738,21 @@ void InteractionManager::DrawInteractions(
   otrap_.Draw(graph_array);
 }
 
-void InteractionManager::WriteOutputs() { xlink_.WriteOutputs(); }
+void InteractionManager::WriteOutputs() {
+  xlink_.WriteOutputs();
+  otrap_.WriteOutputs();
+}
 
 void InteractionManager::InitOutputs(bool reading_inputs,
                                      run_options *run_opts) {
   xlink_.InitOutputs(reading_inputs, run_opts);
+  otrap_.InitOutputs(reading_inputs, run_opts);
 }
 
-void InteractionManager::ReadInputs() { xlink_.ReadInputs(); }
+void InteractionManager::ReadInputs() {
+  xlink_.ReadInputs();
+  otrap_.ReadInputs();
+}
 
 void InteractionManager::InitCrosslinkSpecies(sid_label &slab,
                                               ParamsParser &parser,
@@ -758,11 +765,6 @@ void InteractionManager::InitOpticalTrapSpecies(sid_label &slab,
   otrap_.InitSpecies(slab, parser, seed);
 }
 
-void InteractionManager::InsertOpticalTraps(
-    std::vector<SpeciesBase *> *species) {
-  otrap_.InsertOpticalTraps(species);
-}
-
 void InteractionManager::LoadCrosslinksFromCheckpoints(
     std::string run_name, std::string checkpoint_run_name) {
   xlink_.LoadCrosslinksFromCheckpoints(run_name, checkpoint_run_name);
@@ -771,6 +773,11 @@ void InteractionManager::LoadCrosslinksFromCheckpoints(
 }
 
 void InteractionManager::InsertCrosslinks() { xlink_.InsertCrosslinks(); }
+
+void InteractionManager::InsertOpticalTraps(
+    std::vector<SpeciesBase *> *species) {
+  otrap_.InsertOpticalTraps(species);
+}
 
 bool InteractionManager::CheckDynamicTimestep() {
   if (decrease_dynamic_timestep_) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -210,6 +210,7 @@ void Object::Draw(std::vector<graph_struct *> &graph_array) {
   std::copy(scaled_position_, scaled_position_ + 3, g_.r);
   for (int i = space_->n_periodic; i < n_dim_; ++i) {
     g_.r[i] = position_[i];
+    printf("position_[i] = %f\n", position_[i]);
   }
   std::copy(orientation_, orientation_ + 3, g_.u);
   g_.color = color_;

--- a/src/optical_trap.cpp
+++ b/src/optical_trap.cpp
@@ -6,7 +6,7 @@
 
 #include "cglass/optical_trap.hpp"
 
-OpticalTrap::OpticalTrap(unsigned long seed) : Object(seed) {
+OpticalTrap::OpticalTrap(unsigned long seed) : Object(seed), bead_(seed) {
   SetSID(species_id::optical_trap);
 }
 
@@ -21,9 +21,13 @@ void OpticalTrap::Init(optical_trap_parameters *sparams) {
   sparams_ = sparams;
   trap_spring_ = sparams_->trap_spring;
   diameter_ = sparams_->trap_diameter;
-  bead_diameter_ = sparams_->trap_diameter;
   color_ = sparams_->trap_color;
-  bead_color_ = sparams_->trap_color;
+
+  bead_.SetSpace(space_);
+  bead_.SetNDim(n_dim_);
+  bead_.SetDiameter(sparams_->bead_diameter);
+  bead_.SetColor(sparams_->bead_color, draw_type::fixed);
+  //bead_=Object(0)
   draw_ = draw_type::_from_string(sparams_->draw_type.c_str());
 }
 
@@ -35,6 +39,9 @@ void OpticalTrap::Init(optical_trap_parameters *sparams) {
  * \return Return parameter description
  */
 void OpticalTrap::InsertAndAttach(Object *obj) {
+  attach_obj_ = obj;
+  SetMeshID(-1);
+  AttachObjRelLambda(0); //TODO attach to minus end for now
   const double *obj_pos = obj->GetPosition();
   const double *obj_orient = obj->GetOrientation();
   const double obj_len = obj->GetLength() * .5;
@@ -42,8 +49,81 @@ void OpticalTrap::InsertAndAttach(Object *obj) {
   for (int i = 0; i < 3; ++i) {
     position_[i] = obj_pos[i] - obj_orient[i] * obj_len;
   }
+
   UpdatePeriodic();
+  bead_.SetPosition(position_);
+  bead_.UpdatePeriodic();
 
   return;
 }
 
+/*! \brief Apply force from optical trap to bond
+ *
+ * \return void
+ */
+void OpticalTrap::ApplyOpticalTrapForce() {
+  if (!bond_) {
+    Logger::Error("Anchor attempted to apply forces to nullptr bond");
+  }
+}
+
+void OpticalTrap::AttachObjRelLambda(double lambda) {
+  //if (attach_obj_->GetType() != +obj_type::bond) {
+  //  Logger::Error(
+  //      "Optical traps bound to non-bond objects not yet implemented in "
+  //      "AttachObjLambda.");
+  //}
+
+  if (attach_obj_->GetType() == +obj_type::bond) {
+    bond_ = dynamic_cast<Bond *>(attach_obj_);
+    bond_length_ = bond_->GetLength();
+    if (bond_ == nullptr) {
+      Logger::Error(
+          "Object ptr passed to optical trap was not referencing a bond!");
+    }
+    mesh_ = dynamic_cast<Mesh *>(bond_->GetMeshPtr());
+    if (mesh_ != nullptr) {
+      mesh_n_bonds_ = mesh_->GetNBonds();
+      mesh_length_ = mesh_->GetTrueLength();
+      mesh_lambda_ = mesh_length_ * lambda;
+      bond_lambda_ = mesh_lambda_ - bond_->GetMeshLambda();
+      SetMeshID(bond_->GetMeshID());
+      //  Logger::Error("Object ptr passed to anchor was not referencing a mesh!");
+    } else {
+      bond_lambda_ = lambda * bond_length_;
+    }
+  } else if (attach_obj_->IsMesh()) {
+    mesh_ = dynamic_cast<Mesh *>(attach_obj_);
+    mesh_n_bonds_ = mesh_->GetNBonds();
+    mesh_length_ = mesh_->GetTrueLength();
+    mesh_lambda_ = mesh_length_ * lambda;
+    bond_ = mesh_->GetBondAtLambda(mesh_lambda_);
+    bond_length_ = bond_->GetLength();
+    bond_lambda_ = mesh_lambda_ - bond_->GetMeshLambda();
+    SetMeshID(mesh_->GetMeshID());
+  } else {
+    Logger::Error(
+        "Optical traps bound to non-bond objects not yet implemented in "
+        "AttachObjLambda.");
+  }
+
+  if (bond_lambda_ < 0 || bond_lambda_ > bond_length_) {
+    printf("bond_lambda: %2.2f\n", bond_lambda_);
+    Logger::Error("Lambda passed to anchor does not match length of "
+                  "corresponding bond! lambda: %2.2f, bond_length: %2.2f ",
+                  bond_lambda_, bond_length_);
+  }
+}
+void OpticalTrap::Draw(std::vector<graph_struct *> &graph_array) {
+  Object::Draw(graph_array);
+  double bead_pos[3] = {};
+  double const *const bond_position = bond_->GetPosition();
+  double const *const bond_orientation = bond_->GetOrientation();
+  for (int i = 0; i < n_dim_; ++i) {
+    bead_pos[i] = bond_position[i] +
+                  (bond_lambda_ - 0.5 * bond_length_) * bond_orientation[i];
+  }
+  bead_.SetPosition(bead_pos);
+  bead_.UpdatePeriodic();
+  bead_.Draw(graph_array);
+}

--- a/src/optical_trap.cpp
+++ b/src/optical_trap.cpp
@@ -72,10 +72,13 @@ void OpticalTrap::ApplyOpticalTrapForce() {
   CalculateOpticalTrapForce();
   bond_->AddForce(force_);
   double dlambda[3] = {0};
+  double const *const bond_orientation = bond_->GetOrientation();
   for (int i = 0; i < n_dim_; ++i) {
-    dlambda[i] = (bond_lambda_ - 0.5 * bond_length_) * orientation_[i];
+    dlambda[i] = (bond_lambda_ - 0.5 * bond_length_) * bond_orientation[i];
   }
+  //printf("dlambda = (%f, %f, %f)\n", dlambda[0], dlambda[1], dlambda[2]);
   cross_product(dlambda, force_, torque_, 3);
+  //printf("torque = (%f, %f, %f)\n", torque_[0], torque_[1], torque_[2]);
   bond_->AddTorque(torque_);
 }
 
@@ -115,7 +118,7 @@ void OpticalTrap::AttachObjRelLambda(double lambda) {
     SetMeshID(mesh_->GetMeshID());
   } else {
     Logger::Error(
-        "Optical traps bound to non-bond objects not yet implemented in "
+        "Optical traps for non-bond or non-mesh objects not yet implemented in "
         "AttachObjLambda.");
   }
 

--- a/src/optical_trap.cpp
+++ b/src/optical_trap.cpp
@@ -27,3 +27,23 @@ void OpticalTrap::Init(optical_trap_parameters *sparams) {
   draw_ = draw_type::_from_string(sparams_->draw_type.c_str());
 }
 
+/*! \brief Set position of optical trap relative to obj minus end
+ *
+ *  Detailed description
+ *
+ * \param Object *obj Parameter description
+ * \return Return parameter description
+ */
+void OpticalTrap::InsertAndAttach(Object *obj) {
+  const double *obj_pos = obj->GetPosition();
+  const double *obj_orient = obj->GetOrientation();
+  const double obj_len = obj->GetLength() * .5;
+
+  for (int i = 0; i < 3; ++i) {
+    position_[i] = obj_pos[i] - obj_orient[i] * obj_len;
+  }
+  UpdatePeriodic();
+
+  return;
+}
+

--- a/src/optical_trap.cpp
+++ b/src/optical_trap.cpp
@@ -1,0 +1,29 @@
+/**
+ * @author      : Adam Lamson (adam.lamson@colorado.edu)
+ * @file        : optical_trap
+ * @created     : Friday Jul 03, 2020 14:49:10 MDT
+ */
+
+#include "cglass/optical_trap.hpp"
+
+OpticalTrap::OpticalTrap(unsigned long seed) : Object(seed) {
+  SetSID(species_id::optical_trap);
+}
+
+/*! \brief Initialize optical trap object
+ *
+ *  Detailed description
+ *
+ * \param *sparams Parameter description
+ * \return Return parameter description
+ */
+void OpticalTrap::Init(optical_trap_parameters *sparams) {
+  sparams_ = sparams;
+  trap_spring_ = sparams_->trap_spring;
+  diameter_ = sparams_->trap_diameter;
+  bead_diameter_ = sparams_->trap_diameter;
+  color_ = sparams_->trap_color;
+  bead_color_ = sparams_->trap_color;
+  draw_ = draw_type::_from_string(sparams_->draw_type.c_str());
+}
+

--- a/src/optical_trap_manager.cpp
+++ b/src/optical_trap_manager.cpp
@@ -1,0 +1,16 @@
+/**
+ * @author      : adamlamson (adamlamson@LamsonMacbookPro)
+ * @file        : optical_trap_manager
+ * @created     : Tuesday Jul 07, 2020 11:19:30 MDT
+ */
+
+#include "cglass/optical_trap_manager.hpp"
+
+void OpticalTrapManager::Init(system_parameters *params, space_struct *space,
+                              std::vector<Object *> *objs) {
+  objs_ = objs;
+  update_ = false;
+  params_ = params;
+  space_ = space;
+}
+

--- a/src/optical_trap_manager.cpp
+++ b/src/optical_trap_manager.cpp
@@ -34,7 +34,7 @@ void OpticalTrapManager::InsertOpticalTraps(
 }
 
 void OpticalTrapManager::UpdateOpticalTraps() {
-  for (auto &ot_spec : otrap_species_) {
+  for (auto ot_spec : otrap_species_) {
     ot_spec->ApplyOpticalTrapForces();
   }
 }

--- a/src/optical_trap_manager.cpp
+++ b/src/optical_trap_manager.cpp
@@ -44,3 +44,12 @@ void OpticalTrapManager::Draw(std::vector<graph_struct *> &graph_array) {
     ot_spec->Draw(graph_array);
   }
 }
+
+void OpticalTrapManager::InitOutputs(bool reading_inputs,
+                                     run_options *run_opts) {
+  output_mgr_.Init(params_, &otrap_species_, space_, reading_inputs, run_opts);
+}
+
+void OpticalTrapManager::ReadInputs() { output_mgr_.ReadInputs(); }
+
+void OpticalTrapManager::WriteOutputs() { output_mgr_.WriteOutputs(); }

--- a/src/optical_trap_manager.cpp
+++ b/src/optical_trap_manager.cpp
@@ -6,11 +6,45 @@
 
 #include "cglass/optical_trap_manager.hpp"
 
-void OpticalTrapManager::Init(system_parameters *params, space_struct *space,
-                              std::vector<Object *> *objs) {
-  objs_ = objs;
+void OpticalTrapManager::Init(system_parameters *params, space_struct *space) {
   update_ = false;
   params_ = params;
   space_ = space;
 }
 
+void OpticalTrapManager::InitSpecies(sid_label &slab, ParamsParser &parser,
+                                     unsigned long seed) {
+  if (otrap_species_.size() == 0) {
+    otrap_species_.reserve(parser.GetNOpticalTrapSpecies());
+  }
+  otrap_species_.push_back(new OpticalTrapSpecies(seed));
+  otrap_species_.back()->Init(slab.second, parser);
+  // Delete all optical trap species if there are no optical traps.
+  if (otrap_species_.back()->GetNInsert() <= 0) {
+    delete otrap_species_.back();
+    otrap_species_.pop_back();
+  }
+}
+
+void OpticalTrapManager::InsertOpticalTraps(
+    std::vector<SpeciesBase *> *species) {
+  for (auto it = otrap_species_.begin(); it != otrap_species_.end(); ++it) {
+    (*it)->InsertOpticalTraps(species);
+  }
+}
+
+void OpticalTrapManager::UpdateOpticalTraps() {
+  /* TODO: Add interactions <09-07-20, ARL> */
+}
+
+void OpticalTrapManager::Draw(std::vector<graph_struct *> &graph_array) {
+  for (auto &ot_spec : otrap_species_) {
+    ot_spec->Draw(graph_array);
+  }
+}
+
+//void OpticalTrapManager::GetInteractors(std::vector<Object *> &ixors) {
+//  for (auto it = otrap_species_.begin(); it != otrap_species_.end(); ++it) {
+//    (*it)->GetInteractors(ixors);
+//  }
+//}

--- a/src/optical_trap_manager.cpp
+++ b/src/optical_trap_manager.cpp
@@ -34,7 +34,9 @@ void OpticalTrapManager::InsertOpticalTraps(
 }
 
 void OpticalTrapManager::UpdateOpticalTraps() {
-  /* TODO: Add interactions <09-07-20, ARL> */
+  for (auto &ot_spec : otrap_species_) {
+    ot_spec->ApplyOpticalTrapForces();
+  }
 }
 
 void OpticalTrapManager::Draw(std::vector<graph_struct *> &graph_array) {
@@ -42,9 +44,3 @@ void OpticalTrapManager::Draw(std::vector<graph_struct *> &graph_array) {
     ot_spec->Draw(graph_array);
   }
 }
-
-//void OpticalTrapManager::GetInteractors(std::vector<Object *> &ixors) {
-//  for (auto it = otrap_species_.begin(); it != otrap_species_.end(); ++it) {
-//    (*it)->GetInteractors(ixors);
-//  }
-//}

--- a/src/optical_trap_species.cpp
+++ b/src/optical_trap_species.cpp
@@ -1,0 +1,15 @@
+/**
+ * @author      : adamlamson (adamlamson@LamsonMacbookPro)
+ * @file        : optical_trap_species
+ * @created     : Tuesday Jul 07, 2020 09:41:45 MDT
+ */
+
+#include "cglass/optical_trap_species.hpp"
+
+OpticalTrapSpecies::OpticalTrapSpecies(unsigned long seed) : Species(seed) {
+  SetSID(species_id::optical_trap);
+}
+
+void OpticalTrapSpecies::Init(std::string spec_name, ParamsParser &parser) {
+  Species::Init(spec_name, parser);
+}

--- a/src/optical_trap_species.cpp
+++ b/src/optical_trap_species.cpp
@@ -33,7 +33,7 @@ void OpticalTrapSpecies::InsertOpticalTraps(
         AddMember();
         members_.back().InsertAndAttach(obj);
         const double *const pos = members_.back().GetScaledPosition();
-        printf("pos = %f, %f, %f\n", pos[0], pos[1], pos[2]);
+        Logger::Info("pos = %f, %f, %f\n", pos[0], pos[1], pos[2]);
       }
 
       break;

--- a/src/optical_trap_species.cpp
+++ b/src/optical_trap_species.cpp
@@ -12,4 +12,31 @@ OpticalTrapSpecies::OpticalTrapSpecies(unsigned long seed) : Species(seed) {
 
 void OpticalTrapSpecies::Init(std::string spec_name, ParamsParser &parser) {
   Species::Init(spec_name, parser);
+  attach_species_ = sparams_.attach_species;
+}
+
+void OpticalTrapSpecies::InsertOpticalTraps(
+    std::vector<SpeciesBase *> *species) {
+  for (auto spec : *species) {
+    if (attach_species_.compare(spec->GetSpeciesName()) == 0) {
+      int num_insert = GetNInsert();
+      if (spec->GetNInsert() < num_insert) {
+        Logger::Warning("Number of optical traps exceeds %s number. Will go to "
+                        "max number of species.",
+                        spec->GetSpeciesName().c_str());
+        num_insert = spec->GetNInsert();
+      }
+      std::vector<Object *> attach_objs;
+      spec->GetMemberPtrs(attach_objs);
+
+      for (auto &obj : attach_objs) {
+        AddMember();
+        members_.back().InsertAndAttach(obj);
+        const double *const pos = members_.back().GetScaledPosition();
+        printf("pos = %f, %f, %f\n", pos[0], pos[1], pos[2]);
+      }
+
+      break;
+    }
+  }
 }

--- a/src/optical_trap_species.cpp
+++ b/src/optical_trap_species.cpp
@@ -32,8 +32,8 @@ void OpticalTrapSpecies::InsertOpticalTraps(
       for (auto &obj : attach_objs) {
         AddMember();
         members_.back().InsertAndAttach(obj);
-        const double *const pos = members_.back().GetScaledPosition();
-        Logger::Info("pos = %f, %f, %f\n", pos[0], pos[1], pos[2]);
+        //const double *const pos = members_.back().GetScaledPosition();
+        //Logger::Info("pos = %f, %f, %f\n", pos[0], pos[1], pos[2]);
       }
 
       break;
@@ -46,7 +46,9 @@ void OpticalTrapSpecies::InsertOpticalTraps(
  * \return void
  */
 void OpticalTrapSpecies::ApplyOpticalTrapForces() {
-  for (auto &otrap : members_) {
-    otrap.ApplyOpticalTrapForce();
+  if (params_->no_midstep || params_->i_step % 2 == 1) {
+    for (auto &otrap : members_) {
+      otrap.ApplyOpticalTrapForce();
+    }
   }
 }

--- a/src/optical_trap_species.cpp
+++ b/src/optical_trap_species.cpp
@@ -40,3 +40,13 @@ void OpticalTrapSpecies::InsertOpticalTraps(
     }
   }
 }
+
+/*! \brief Apply all the forces from optical traps to attached objects
+ *
+ * \return void
+ */
+void OpticalTrapSpecies::ApplyOpticalTrapForces() {
+  for (auto &otrap : members_) {
+    otrap.ApplyOpticalTrapForce();
+  }
+}

--- a/src/params_parser.cpp
+++ b/src/params_parser.cpp
@@ -22,6 +22,9 @@ void ParamsParser::CheckDuplicateLabels() {
     if (species_id::_from_string(labels_[i].first.c_str()) ==
         +species_id::crosslink) {
       n_crosslinks_++;
+    } else if (species_id::_from_string(labels_[i].first.c_str()) ==
+               +species_id::optical_trap) {
+      n_optical_traps_++;
     } else {
       n_species_++;
     }
@@ -66,7 +69,7 @@ ParamsParser::GetNewSpeciesParameters(species_id sid, std::string spec_name) {
                 spec_name.c_str());
   for (auto it = species_node_.begin(); it != species_node_.end(); ++it) {
     if (it->first.as<std::string>().compare(sid_str) == 0) {
-      if (it->second.IsMap() && spec_name.compare("species") == 0){
+      if (it->second.IsMap() && spec_name.compare("species") == 0) {
         return parse_species_params(sid_str, it->second, sim_node_);
       } else if (it->second.IsSequence()) {
         for (int i = 0; i < it->second.size(); ++i) {

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -147,8 +147,6 @@ void RigidFilament::Integrate() {
     // Update the orientation due to torques and random rotation
     AddRandomReorientation();
   }
-  // double f_mag = sqrt(dot_product(n_dim_, force_, force_));
-  // printf("f_mag = %f\n", f_mag);
 
   UpdatePeriodic();
   UpdateSitePositions();

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -280,6 +280,10 @@ void Simulation::InitSpecies() {
       ix_mgr_.InitCrosslinkSpecies(*slab, parser_, rng_->GetSeed());
       continue;
     }
+    if (sid == +species_id::optical_trap) {
+      ix_mgr_.InitOpticalTrapSpecies(*slab, parser_, rng_->GetSeed());
+      continue;
+    }
     species_.push_back(species_factory.CreateSpecies(sid, rng_->GetSeed()));
     species_.back()->Init(slab->second, parser_);
     if (species_.back()->GetNInsert() > 0) {
@@ -443,6 +447,8 @@ void Simulation::InsertSpecies(bool force_overlap, bool processing) {
   }
   /* Initialize static crosslink positions */
   ix_mgr_.InsertCrosslinks();
+  /* Initialize optical traps attached to species */
+  ix_mgr_.InsertOpticalTraps(&species_);
   /* Should do this all the time to force object counting */
   if (params_.load_checkpoint) {
     for (auto spec = species_.begin(); spec != species_.end(); ++spec) {
@@ -450,6 +456,7 @@ void Simulation::InsertSpecies(bool force_overlap, bool processing) {
     }
     ix_mgr_.LoadCrosslinksFromCheckpoints(run_name_,
                                           params_.checkpoint_run_name);
+    //TODO Load optical traps from checkpoints
   }
 
   ix_mgr_.ResetCellList(); // Forces rebuild cell list without redundancy
@@ -510,6 +517,7 @@ void Simulation::GetGraphicsStructure() {
   for (auto it = species_.begin(); it != species_.end(); ++it) {
     (*it)->Draw(graph_array_);
   }
+
   /* Visualize interaction forces, crosslinks, etc */
   ix_mgr_.DrawInteractions(graph_array_);
 }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -246,7 +246,8 @@ void Simulation::InitGraphics() {
 #ifndef NOGRAPH
   // Initialize graphics structures
   graphics_.Init(&graph_array_, space_.GetStruct(), background_color,
-                 params_.draw_boundary, params_.auto_graph);
+                 params_.draw_boundary, params_.auto_graph,
+                 params_.object_opacity);
 
 // This line was interferring with graphics on Windows, and removing it did no
 // harm


### PR DESCRIPTION
## Description of changes
Added optical traps that can attach sphero-like objects.

## Changes in behavior
Creates and graphs optical trap objects that are defined by the species they attach and the spring constant of the traps. Not all objects have to be trapped. You can now set the opacity of sphero-like objects too.

## Anything unresolved?
Improvements and functionalities will be added as optical trap project progresses. Cannot currently trap crosslink- or anchor-like objects.
