### PR TITLE
Add include_directories(${INCLUDES}) back into src/CMakeLists.txt

### DIFF
--- a/include/cglass/params_parser.hpp
+++ b/include/cglass/params_parser.hpp
@@ -2,7 +2,7 @@
 #define _CGLASS_PARAMS_PARSER_H_
 
 #include "auxiliary.hpp"
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
 
 typedef std::pair<std::string, std::string> sid_label;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(yaml-cpp REQUIRED)
+message("-- Found yaml-cpp: ${YAML_CPP_INCLUDE_DIR}")
 find_package(GSL REQUIRED)
 find_package(FFTW REQUIRED)
 
@@ -26,6 +27,7 @@ if (GRAPH)
 else()
   add_definitions(-DNOGRAPH=TRUE)
 endif()
+include_directories(${INCLUDES})
 
 if(DEBUG)
     add_definitions(-DDEBUG=TRUE)


### PR DESCRIPTION
## Description of changes
One line change to include external header files into C-GLASS.

## Changes in behavior
Cmake wasn't including external headers if not in system path. Now headers are included and will compile from source.

## Anything unresolved?
Don't think so.
