### PR TITLE
Fix time units

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -15,6 +15,7 @@ boundary : [0, int]                  # 0: No boundary condition constraints.
 system_radius : [100, double]        # Sets system volume. 1D system length is 2 x system_radius.
 n_steps : [1000000, int]             # Number of steps to run simulation before completion.
 i_step: [0, int]                     # Internal parameter used for tracking simulation iteration.
+on_midstep: [false, bool]               # Internal parameter, whether current step is midstep.
 prev_step: [0, int]                  # Internal parameter, previous simulation iteration.
 delta : [0.001, double]              # Simulation time duration between each simulation step.
 dynamic_timestep : [false, bool]     # Change timestep if necessary to avoid unphysical forces
@@ -275,7 +276,6 @@ br_bead:
 spherocylinder:
   diffusion_analysis: [false, bool]
   n_diffusion_samples: [1, int]
-  midstep: [false, bool]
 spindle:
   n_filaments_bud: [0, int]
   n_filaments_mother: [0, int]

--- a/include/cglass/auxiliary.hpp
+++ b/include/cglass/auxiliary.hpp
@@ -7,7 +7,6 @@
 #include "parameters.hpp"
 #include "logger.hpp"
 #include "space_base.hpp"
-
 extern bool early_exit;
 
 #include "function_headers.hpp"

--- a/include/cglass/bead_spring.hpp
+++ b/include/cglass/bead_spring.hpp
@@ -40,7 +40,6 @@ public:
   // void DiffusionValidationInit();
   virtual void Integrate(bool midstep);
   // virtual void Draw(std::vector<graph_struct*> * graph_array);
-  virtual void UpdatePosition() {}
   virtual void UpdatePosition(bool midstep);
   double const GetLength() { return length_; }
   double const GetDriving() { return driving_factor_; }

--- a/include/cglass/centrosome.hpp
+++ b/include/cglass/centrosome.hpp
@@ -25,7 +25,6 @@ class Centrosome : public Object {
  public:
   Centrosome();
   void Init();
-  void UpdatePosition() {}
   void UpdatePosition(bool midstep);
   virtual std::vector<Object *> GetInteractors();
   virtual int GetCount();

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -13,7 +13,6 @@ typedef std::vector<Crosslink>::iterator xlink_iterator;
 class CrosslinkSpecies : public Species<Crosslink, species_id::crosslink> {
 private:
   bool *update_;
-  bool midstep_ = true;
   std::string checkpoint_file_;
   double *obj_size_; // Total area/length of all the objects in the system
   double xlink_concentration_;
@@ -62,6 +61,7 @@ public:
   void UpdatePositions();
   void UpdateBindRate();
   void CleanUp();
+  void ClearNeighbors();
   void Draw(std::vector<graph_struct *> &graph_array);
   void BindCrosslinkObj(Object *obj);
   void AddNeighborToAnchor(Object *anchor, Object *neighbor);

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -104,7 +104,6 @@
   default_config["br_bead"]["draw_shape"] = "sphere";
   default_config["spherocylinder"]["diffusion_analysis"] = "false";
   default_config["spherocylinder"]["n_diffusion_samples"] = "1";
-  default_config["spherocylinder"]["midstep"] = "false";
   default_config["spindle"]["n_filaments_bud"] = "0";
   default_config["spindle"]["n_filaments_mother"] = "0";
   default_config["spindle"]["alignment_potential"] = "false";
@@ -167,6 +166,7 @@
   default_config["system_radius"] = "100";
   default_config["n_steps"] = "1000000";
   default_config["i_step"] = "0";
+  default_config["on_midstep"] = "false";
   default_config["prev_step"] = "0";
   default_config["delta"] = "0.001";
   default_config["dynamic_timestep"] = "false";

--- a/include/cglass/filament.hpp
+++ b/include/cglass/filament.hpp
@@ -112,8 +112,8 @@ public:
   virtual void InsertAt(const double *const new_pos, const double *const u);
   virtual void Integrate();
   virtual void Draw(std::vector<graph_struct *> &graph_array);
-  virtual void UpdatePosition() {}
   virtual void UpdatePosition(bool midstep);
+  virtual void UpdatePosition() {}
   double const GetLength() { return length_; }
   double const GetDriving() { return driving_factor_; }
   double const GetPersistenceLength() { return bending_stiffness_; }

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -137,7 +137,6 @@ struct species_parameters<species_id::spherocylinder>
     : public species_base_parameters {
   bool diffusion_analysis = false;
   int n_diffusion_samples = 1;
-  bool midstep = false;
 };
 typedef species_parameters<species_id::spherocylinder> spherocylinder_parameters;
 
@@ -218,6 +217,7 @@ struct system_parameters {
   double system_radius = 100;
   int n_steps = 1000000;
   int i_step = 0;
+  bool on_midstep = false;
   int prev_step = 0;
   double delta = 0.001;
   bool dynamic_timestep = false;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -32,6 +32,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.n_steps = it->second.as<int>();
     } else if (param_name.compare("i_step")==0) {
     params.i_step = it->second.as<int>();
+    } else if (param_name.compare("on_midstep")==0) {
+    params.on_midstep = it->second.as<bool>();
     } else if (param_name.compare("prev_step")==0) {
     params.prev_step = it->second.as<int>();
     } else if (param_name.compare("delta")==0) {
@@ -553,8 +555,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.diffusion_analysis = jt->second.as<bool>();
       } else if (param_name.compare("n_diffusion_samples")==0) {
       params.n_diffusion_samples = jt->second.as<int>();
-      } else if (param_name.compare("midstep")==0) {
-      params.midstep = jt->second.as<bool>();
       } else {
         Logger::Warning("Unrecognized %s parameter: '%s'", sid.c_str(), param_name.c_str());
       }

--- a/include/cglass/simulation.hpp
+++ b/include/cglass/simulation.hpp
@@ -10,6 +10,8 @@ class Simulation {
  private:
   UNIT_TEST
   int i_step_ = 0;
+  double step_fact_;
+  int inv_step_fact_;
   int log_interval_ = 10;
   int n_steps_;
   int frame_num_ = 0;

--- a/include/cglass/spherocylinder_species.hpp
+++ b/include/cglass/spherocylinder_species.hpp
@@ -7,7 +7,6 @@
 class SpherocylinderSpecies
     : public Species<Spherocylinder, species_id::spherocylinder> {
 protected:
-  bool midstep_;
   double **pos0_, **u0_, *msd_, *msd_err_, *vcf_, *vcf_err_;
   int time_, time_avg_interval_, n_samples_;
   std::fstream diff_file_;

--- a/include/cglass/spindle.hpp
+++ b/include/cglass/spindle.hpp
@@ -41,8 +41,7 @@ public:
   void Init(spindle_parameters *sparams);
   void GenerateNucleationSites();
   void InsertFilament(int i_fil);
-  void UpdatePosition() {}
-  void UpdatePosition(bool midstep);
+  void UpdatePosition();
   virtual void GetInteractors(std::vector<Object *> &ix);
   virtual int GetCount();
   virtual void Draw(std::vector<graph_struct *> &graph_array);

--- a/include/cglass/spindle_species.hpp
+++ b/include/cglass/spindle_species.hpp
@@ -6,7 +6,6 @@
 
 class SpindleSpecies : public Species<Spindle, species_id::spindle> {
 protected:
-  bool midstep_ = true;
   filament_parameters fparams_;
 
 public:

--- a/src/br_bead.cpp
+++ b/src/br_bead.cpp
@@ -61,7 +61,7 @@ void BrBead::UpdatePosition() {
   SetPrevPosition(GetPosition());
   SetPrevOrientation(GetOrientation());
   ApplyForcesTorques();
-  if (!sparams_->stationary_flag)
+  if (!params_->on_midstep && !sparams_->stationary_flag)
     Integrate();
   UpdatePeriodic();
 }

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -430,8 +430,10 @@ void CrosslinkSpecies::UpdatePositions() {
        We do this every half step only, because the fullstep tether forces are
        handled by the crosslink update on the full step */
     ApplyCrosslinkTetherForces();
+    // Add a step to clear neighbors on the midstep- otherwise they only get
+    // cleared on the full step and are double-counted
+    ClearNeighbors();
   }
-  midstep_ = !midstep_;
   // for (auto it=members_.begin(); it!=members_.end(); ++it) {
   // it->SanityCheck();
   //}
@@ -647,6 +649,13 @@ void CrosslinkSpecies::ReadSpecs() {
   }
   for (auto it = members_.begin(); it != members_.end(); ++it) {
     it->ReadSpec(ispec_file_);
+  }
+}
+
+void CrosslinkSpecies::ClearNeighbors() {
+  // Clear all anchor neighborlists.
+  for (auto it = members_.begin(); it != members_.end(); ++it) {
+    it->ClearNeighbors();
   }
 }
 

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -420,10 +420,7 @@ void CrosslinkSpecies::GetAnchorInteractors(std::vector<Object *> &ixors) {
 void CrosslinkSpecies::UpdatePositions() {
   /* Only do this every other step (assuming flexible filaments with midstep)
    */
-  if (params_->no_midstep) {
-    UpdateBoundCrosslinks();
-    CalculateBindingFree();
-  } else if (params_->i_step % 2 == 0) {
+  if (!params_->on_midstep) {
     /* First update bound crosslinks state and positions */
     UpdateBoundCrosslinks();
     /* Calculate implicit binding of crosslinks from solution */

--- a/src/filament.cpp
+++ b/src/filament.cpp
@@ -1032,7 +1032,7 @@ void Filament::ApplyInteractionForces() {
     sites_[i + 1].AddForce(pure_torque);
     // The driving factor is a force per unit length,
     // so need to multiply by bond length to get f_dr on bond
-    if (params_->i_step > eq_steps_) {
+    if (params_->i_step > (eq_steps_*(params_->no_midstep?1:2))) {
       double f_dr[3] = {};
       double mag = 0.5 * driving_factor_ * bond_length_;
       if (sparams_->drive_from_bond_center) {

--- a/src/filament_curvature_cluster_analysis.cpp
+++ b/src/filament_curvature_cluster_analysis.cpp
@@ -161,7 +161,7 @@ void CurvatureClusterAnalysis::InitAnalysis() {
   InitLabels();
 }
 void CurvatureClusterAnalysis::RunAnalysis() {
-  if (params_->i_step < sparams_->n_equil) {
+  if ((params_->i_step) < ((sparams_->n_equil)*(params_->no_midstep?1:2))) {
     return;
   }
   double dr[3] = {0};

--- a/src/filament_species.cpp
+++ b/src/filament_species.cpp
@@ -155,6 +155,7 @@ void FilamentSpecies::UpdatePositions() {
     it->UpdatePosition(midstep_);
 #endif
 
+  // Richelle check- shouldn't this be only if using midsteps?
   midstep_ = !midstep_;
   if (sparams_.error_analysis) {
     RunErrorAnalysis();

--- a/src/receptor.cpp
+++ b/src/receptor.cpp
@@ -59,7 +59,11 @@ void Receptor::SetPCObject(Object* pc_object) {
 
 // Use PointCover object positions to update
 void Receptor::UpdatePosition() {
-  if (sparams_->stationary_flag)
+  // Update position only on the midstep to save time, since Receptors
+  // currently can't lie on Filaments. If Receptors on Filaments is implemented,
+  // change to update on main step & midstep if attached to Filament (which updates 
+  // on both), and only on main step if attached to anything else.
+  if (params_->on_midstep || sparams_->stationary_flag)
     return;
   // Check that the PointCover is associated with a species
   if (pc_species_) {

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -247,7 +247,7 @@ double const RigidFilament::GetVolume() {
 
 void RigidFilament::UpdatePosition() {
   ApplyForcesTorques();
-  if (!sparams_->stationary_flag)
+  if (!params_->on_midstep && !sparams_->stationary_flag)
     Integrate();
   eq_steps_count_++;
 }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -216,8 +216,6 @@ void Simulation::InitSimulation() {
   ix_mgr_.InitInteractions();
   InsertSpecies(params_.load_checkpoint, params_.load_checkpoint);
   InitOutputs();
-  /* With halfstep algorithm, each step only moves the simulation forward
-     by 1/2 delta. Defining step_fact prevents unnecessary if-else statements.*/
   step_fact_ = params_.no_midstep ? 1. : .5;
   inv_step_fact_ = params_.no_midstep ? 1 : 2;
   if (params_.graph_flag) {
@@ -587,6 +585,8 @@ void Simulation::InitProcessing(run_options run_opts) {
      outputs */
   params_.load_checkpoint = 0;
 
+  step_fact_ = params_.no_midstep ? 1. : .5;
+  inv_step_fact_ = params_.no_midstep ? 1 : 2;
   space_.Init(&params_);
   InitObjects();
   cortex_ = new Cortex(rng_->GetSeed());

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -35,17 +35,14 @@ void Simulation::RunSimulation() {
    also update other objects' positions on every even step too (e.g. xlinks). */
   double delta_diff = 0;
   bool midstep = true;
-  /* With halfstep algorithm, each step only moves the simulation forward
-     by 1/2 delta. Defining step_fact prevents unnecessary if-else statements.*/
-  double step_fact = params_.no_midstep ? 1. : .5;
   time_ = 0;
   params_.i_step = 0;
-  for (i_step_ = 1; params_.i_step < params_.n_steps + 1; ++i_step_) {
-    time_ += step_fact * Object::GetDelta();
+  for (i_step_ = 1; params_.i_step <= (inv_step_fact_*params_.n_steps); ++i_step_) {
+    time_ += step_fact_ * Object::GetDelta();
     params_.i_step = i_step_;
     if (params_.dynamic_timestep) {
       // Calculate nominal timestep
-      params_.i_step = (int)round(time_ / (step_fact * params_.delta));
+      params_.i_step = (int)round(time_ / (step_fact_ * params_.delta));
     }
     // Output progress
     PrintComplete();
@@ -65,7 +62,7 @@ void Simulation::RunSimulation() {
         time_ -= Object::GetDelta();
         i_step_ -= 2;
       } else {
-        time_ -= step_fact * Object::GetDelta();
+        time_ -= step_fact_ * Object::GetDelta();
         i_step_ -= 1;
       }
       midstep = true;
@@ -74,8 +71,8 @@ void Simulation::RunSimulation() {
       if (Object::GetDelta() < 1e-12) {
         Logger::Warning(
             "Dynamic delta has become ridiculously tiny! (%2.14f) Likely an"
-            " interaction error occurred. Triggering an early exit. %d",
-            Object::GetDelta(), i_step_);
+            " interaction error occurred. Triggering an early exit. %f",
+            Object::GetDelta(), step_fact_*i_step_);
         return;
       }
       continue;
@@ -112,7 +109,7 @@ void Simulation::RunSimulation() {
  * in a single line printed to standard output. */
 void Simulation::PrintComplete() {
   long iteration = params_.i_step * 10;
-  long steps = params_.n_steps;
+  long steps = params_.n_steps * inv_step_fact_;
   if (iteration % steps == 0) {
     Logger::Info("%d%% complete", 10 * iteration / steps);
     if (params_.dynamic_timestep) {
@@ -120,7 +117,7 @@ void Simulation::PrintComplete() {
       Logger::Info("Current timestep: %2.10f", Object::GetDelta());
     }
   }
-  if (i_step_ == log_interval_ + 1) {
+  if (i_step_ == inv_step_fact_*(log_interval_ + 1)) {
     Logger::Info("%d steps completed", log_interval_);
     log_interval_ = (int)floor(2 * log_interval_);
     if (params_.dynamic_timestep) {
@@ -128,7 +125,7 @@ void Simulation::PrintComplete() {
       Logger::Info("Current timestep: %2.10f", Object::GetDelta());
     }
   }
-  Logger::Trace("*****Step %d*****", i_step_);
+  Logger::Trace("*****Step %f*****", i_step_ * step_fact_);
 }
 
 /* Update the positions of all objects in the system using numerical
@@ -158,7 +155,7 @@ void Simulation::ZeroForces() {
 /* Update system pressure, volume and rescale system size if necessary,
  * handling periodic boundaries in a sane way. */
 void Simulation::Statistics() {
-  if (params_.i_step % params_.n_thermo == 0 &&
+  if (params_.i_step % (inv_step_fact_*params_.n_thermo) == 0 &&
       params_.i_step != params_.prev_step && params_.i_step > 0) {
     Logger::Debug("Calculating system pressure and volume");
     /* Calculate system pressure from stress tensor */
@@ -219,6 +216,10 @@ void Simulation::InitSimulation() {
   ix_mgr_.InitInteractions();
   InsertSpecies(params_.load_checkpoint, params_.load_checkpoint);
   InitOutputs();
+  /* With halfstep algorithm, each step only moves the simulation forward
+     by 1/2 delta. Defining step_fact prevents unnecessary if-else statements.*/
+  step_fact_ = params_.no_midstep ? 1. : .5;
+  inv_step_fact_ = params_.no_midstep ? 1 : 2;
   if (params_.graph_flag) {
     InitGraphics();
   }
@@ -263,7 +264,7 @@ void Simulation::InitGraphics() {
   if (params_.movie_flag) {
     // Record bmp image of frame into movie_directory
     grabber(graphics_.windx_, graphics_.windy_, params_.movie_directory,
-            (int)params_.i_step / params_.n_graph);
+            (int)params_.i_step / (inv_step_fact_*params_.n_graph));
   }
 #endif
 }
@@ -495,7 +496,7 @@ void Simulation::ClearSpecies() {
 /* Update the OpenGL graphics window */
 void Simulation::Draw(bool single_frame) {
 #ifndef NOGRAPH
-  if (params_.graph_flag && params_.i_step % params_.n_graph == 0 &&
+  if (params_.graph_flag && params_.i_step % (inv_step_fact_*params_.n_graph) == 0 &&
       params_.i_step != params_.prev_step) {
     Logger::Trace("Drawing graphable objects");
     /* Get updated object positions and orientations */
@@ -551,7 +552,7 @@ void Simulation::WriteOutputs() {
   ix_mgr_.WriteOutputs();
   /* If we are analyzing run time and this is the last step, record final time
    * here. */
-  if (params_.time_analysis && params_.i_step == params_.n_steps) {
+  if (params_.time_analysis && params_.i_step == inv_step_fact_*params_.n_steps) {
     double cpu_final_time = cpu_time();
     double cpu_time = cpu_final_time - cpu_init_time_;
     Logger::Info("CPU Time for Initialization: %2.6f", cpu_init_time_);
@@ -627,9 +628,9 @@ void Simulation::InitProcessing(run_options run_opts) {
 void Simulation::RunProcessing(run_options run_opts) {
   Logger::Info("Processing outputs for %s", run_name_.c_str());
 
-  for (i_step_ = 0; i_step_ <= params_.n_steps; ++i_step_) {
+  for (i_step_ = 1; i_step_ <= (params_.n_steps*inv_step_fact_); ++i_step_) {
     params_.i_step = i_step_;
-    time_ = params_.i_step * params_.delta;
+    time_ = params_.i_step * params_.delta * step_fact_;
     PrintComplete();
     if (early_exit) {
       break;
@@ -640,14 +641,14 @@ void Simulation::RunProcessing(run_options run_opts) {
       ix_mgr_.Convert();
       continue;
     }
-    if (run_opts.analysis_flag && params_.i_step >= params_.n_steps_equil) {
+    if (run_opts.analysis_flag && params_.i_step >= (inv_step_fact_*params_.n_steps_equil)) {
       bool struct_update = false;
       /* Check if we are running any species analysis to determine whether we
        * run structure analysis */
       for (auto it = species_.begin(); it != species_.end(); ++it) {
         if (((*it)->GetPositFlag() &&
-             params_.i_step % (*it)->GetNPosit() == 0) ||
-            ((*it)->GetSpecFlag() && params_.i_step % (*it)->GetNSpec() == 0)) {
+             params_.i_step % (inv_step_fact_*(*it)->GetNPosit()) == 0) ||
+            ((*it)->GetSpecFlag() && params_.i_step % (inv_step_fact_*(*it)->GetNSpec()) == 0)) {
           struct_update = true;
           break;
         }
@@ -656,9 +657,9 @@ void Simulation::RunProcessing(run_options run_opts) {
         ix_mgr_.InteractionAnalysis();
         for (auto it = species_.begin(); it != species_.end(); ++it) {
           if (((*it)->GetPositFlag() &&
-               params_.i_step % (*it)->GetNPosit() == 0) ||
+               params_.i_step % (inv_step_fact_*(*it)->GetNPosit()) == 0) ||
               ((*it)->GetSpecFlag() &&
-               params_.i_step % (*it)->GetNSpec() == 0)) {
+               params_.i_step % (inv_step_fact_*(*it)->GetNSpec() == 0))) {
             (*it)->RunAnalysis();
           }
         }
@@ -670,9 +671,9 @@ void Simulation::RunProcessing(run_options run_opts) {
   }
   Draw(run_opts.single_frame);
   early_exit = false;
-  Logger::Info("Early exit triggered on step %d. Ending simulation.",
-               params_.i_step);
-  if (run_opts.analysis_flag && i_step_ > params_.n_steps_equil) {
+  Logger::Info("Early exit triggered on step %f. Ending simulation.",
+               params_.i_step*step_fact_);
+  if (run_opts.analysis_flag && i_step_ > (inv_step_fact_*params_.n_steps_equil)) {
     for (auto it = species_.begin(); it != species_.end(); ++it) {
       (*it)->FinalizeAnalysis();
     }

--- a/src/species_base.cpp
+++ b/src/species_base.cpp
@@ -71,12 +71,6 @@ void SpeciesBase::InitSpecFile(std::string run_name) {
 
 bool SpeciesBase::HandleEOF() {
   if (++spec_file_iterator_) {
-    //if (params_->i_step < params_->n_steps_equil) {
-      //params_->n_steps_equil -= params_->i_step;
-    //} else {
-      //params_->n_steps_equil = 0;
-    //}
-    //params_->i_step = 0;
     std::ostringstream file_name, nload;
     std::string sid_str = sid_._to_string();
     file_name << params_->run_name;

--- a/src/spherocylinder.cpp
+++ b/src/spherocylinder.cpp
@@ -28,7 +28,7 @@ void Spherocylinder::InsertSpherocylinder() {
 void Spherocylinder::UpdatePosition() {
   SetPrevPosition(position_);
   ApplyForcesTorques();
-  if (!sparams_->stationary_flag)
+  if (!params_->on_midstep && !sparams_->stationary_flag)
     Integrate();
   UpdatePeriodic();
 }

--- a/src/spherocylinder_species.cpp
+++ b/src/spherocylinder_species.cpp
@@ -6,7 +6,6 @@ SpherocylinderSpecies::SpherocylinderSpecies(unsigned long seed)
 }
 void SpherocylinderSpecies::Init(std::string spec_name, ParamsParser &parser) {
   Species::Init(spec_name, parser);
-  midstep_ = sparams_.midstep;
 }
 
 void SpherocylinderSpecies::InitAnalysis() {
@@ -145,7 +144,7 @@ void SpherocylinderSpecies::FinalizeDiffusionAnalysis() {
   diff_file_.precision(16);
   diff_file_.setf(std::ios::fixed);
   diff_file_.setf(std::ios::showpoint);
-  double midterm = (midstep_ ? 0.5 : 1);
+  double midterm = (params_->no_midstep ? 1 : 0.5);
   for (int t = 0; t < time_avg_interval_; ++t) {
     diff_file_ << midterm * (t + 1) * params_->delta * GetNPosit() << " "
                << msd_[t] << " " << msd_err_[t] << " " << vcf_[t] << " "

--- a/src/spindle.cpp
+++ b/src/spindle.cpp
@@ -141,8 +141,7 @@ void Spindle::ResetSitePositions() {
   }
 }
 
-void Spindle::UpdatePosition(bool midstep) {
-  midstep_ = midstep;
+void Spindle::UpdatePosition() {
   ApplyForcesTorques();
 #ifdef ENABLE_OPENMP
   int max_threads = omp_get_max_threads();
@@ -163,25 +162,25 @@ void Spindle::UpdatePosition(bool midstep) {
 #pragma omp for
     for (int i = 0; i < max_threads; ++i) {
       for (auto it = chunks[i].first; it != chunks[i].second; ++it) {
-        it->UpdatePosition(midstep);
+        it->UpdatePosition(params_->on_midstep);
       }
     }
   }
 #else
   for (filament_iterator it = filaments_.begin(); it != filaments_.end();
        ++it) {
-    it->UpdatePosition(midstep);
+    it->UpdatePosition(params_->on_midstep);
   }
 #endif
   SetPrevPosition(position_);
-  if (!midstep_ && !sparams_->stationary_flag) {
+  if (!params_->on_midstep && !sparams_->stationary_flag) {
     Integrate();
   }
 }
 
 void Spindle::ApplyForcesTorques() {
   ApplyNucleationSiteForces();
-  if (!midstep_) {
+  if (!params_->on_midstep) {
     ApplySpindleForces();
   }
 }
@@ -244,7 +243,7 @@ void Spindle::Draw(std::vector<graph_struct *> &graph_array) {
 }
 
 void Spindle::UpdateDrTot() {
-  if (midstep_) {
+  if (params_->on_midstep) {
     return;
   }
   Object::UpdateDrTot();

--- a/src/spindle_species.cpp
+++ b/src/spindle_species.cpp
@@ -17,9 +17,8 @@ void SpindleSpecies::Init(std::string spec_name, ParamsParser &parser) {
 
 void SpindleSpecies::UpdatePositions() {
   for (auto it = members_.begin(); it != members_.end(); ++it) {
-    it->UpdatePosition(midstep_);
+    it->UpdatePosition();
   }
-  midstep_ = !midstep_;
 }
 
 void SpindleSpecies::ArrangeMembers() {

--- a/tests/simulation_manager_test.hpp
+++ b/tests/simulation_manager_test.hpp
@@ -30,7 +30,6 @@ private:
                            " seed: 314159,"
                            " n_steps: 100000,"
                            " n_dim: 2,"
-                           " no_midstep: true,"
                            " system_radius: 20,"
                            " rigid_filament: [{name: rig1, num: 1, length: 5, stationary_flag: true,"
                              " insertion_type: custom, insert_file: fil1.yaml},"


### PR DESCRIPTION
## Description of changes
Time outputs aren't off by a factor of two; anchors do not double-count interactors. In midstep algorithm, brownian objects only travel on non-midstep (otherwise effective diffusion factor was 2x too high).

## Changes in behavior
No longer gives output time\*2 or output steps\*2- gives step values of x.5 for midsteps. Do not need to multiply delta by 0.5.

n_steps now refers to total _full steps_, not total halfsteps. For example, if a user chooses 100 steps with a midstep algorithm and 100 steps without a midstep algorithm, the timescales and behavior should be nearly identical- the one with midsteps will take longer, but may be more stable.

## Anything unresolved?
Some scripts in analysis may now have their time values too low by a factor of 0.5 (if a 0.5 factor was introduced in the script to account for the time/steps being off). Since these are not part of C-GLASS itself, I didn't edit them.
