### PR TITLE
Constraining motion to y

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -138,8 +138,8 @@ rigid_filament:
                                        # will never physically overlap if they do not begin overlapping.
                                        # This only works for two filaments. Warning will be thrown otherwise.
   constrain_to_move_in_y: [false, bool] # Filaments won't rotate and will only move in the y direction 
-																				#(note: it seems the constrain_motion_flag is supposed to due this,
-																			  #	but it's not working)
+					#(note: it seems the constrain_motion_flag is supposed to due this,
+					#but it's not working)
   packing_fraction: [-1, double]    # if num > 0, and packing fraction > 0, filaments are inserted
   #                                  # until the ratio filament to system volumes match this value.
   n_equil: [0, int]                 # internal filament parameter used for shuffling.

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -137,6 +137,9 @@ rigid_filament:
   constrain_motion_flag: [false, bool] # If true, rigid filaments will move in planes such that two filaments
                                        # will never physically overlap if they do not begin overlapping.
                                        # This only works for two filaments. Warning will be thrown otherwise.
+  constrain_to_move_in_y: [false, bool] # Filaments won't rotate and will only move in the y direction 
+																				#(note: it seems the constrain_motion_flag is supposed to due this,
+																			  #	but it's not working)
   packing_fraction: [-1, double]    # if num > 0, and packing fraction > 0, filaments are inserted
   #                                  # until the ratio filament to system volumes match this value.
   n_equil: [0, int]                 # internal filament parameter used for shuffling.

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -16,6 +16,7 @@
   default_config["rigid_filament"]["max_length"] = "500";
   default_config["rigid_filament"]["min_length"] = "5";
   default_config["rigid_filament"]["constrain_motion_flag"] = "false";
+  default_config["rigid_filament"]["constrain_to_move_in_y"] = "false";
   default_config["rigid_filament"]["packing_fraction"] = "-1";
   default_config["rigid_filament"]["n_equil"] = "0";
   default_config["filament"]["packing_fraction"] = "-1";

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -31,6 +31,7 @@ struct species_parameters<species_id::rigid_filament>
   double max_length = 500;
   double min_length = 5;
   bool constrain_motion_flag = false;
+  bool constrain_to_move_in_y = false;
   double packing_fraction = -1;
   int n_equil = 0;
 };

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -262,6 +262,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.min_length = jt->second.as<double>();
       } else if (param_name.compare("constrain_motion_flag")==0) {
       params.constrain_motion_flag = jt->second.as<bool>();
+      } else if (param_name.compare("constrain_to_move_in_y")==0) {
+      params.constrain_to_move_in_y = jt->second.as<bool>();
       } else if (param_name.compare("packing_fraction")==0) {
       params.packing_fraction = jt->second.as<double>();
       } else if (param_name.compare("n_equil")==0) {

--- a/include/cglass/rigid_filament.hpp
+++ b/include/cglass/rigid_filament.hpp
@@ -21,6 +21,7 @@ private:
                                  // by this unit vector.
 
   bool zero_temperature_ = false;
+  bool constrain_to_move_in_y_ = false;
   int n_step_ = 0;
   int eq_steps_ = 0;
   int eq_steps_count_ = 0;
@@ -33,6 +34,7 @@ private:
   void UpdateSitePositions();
 
   void ApplyForcesTorques();
+  void ApplyForcesTorquesYOnly();
   void ApplyInteractionForces();
 
   void SetParameters();
@@ -49,6 +51,7 @@ protected:
   void InsertRigidFilament(std::string insertion_type, double buffer = -1);
   void GetBodyFrame();
   void AddRandomDisplacement();
+  void AddRandomYDisplacement();
   void AddRandomReorientation();
 
 public:

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -15,6 +15,7 @@ void RigidFilament::SetParameters() {
   max_length_ = sparams_->max_length;
   min_length_ = sparams_->min_length;
   zero_temperature_ = params_->zero_temperature; // include thermal forces
+  constrain_to_move_in_y_ = sparams_->constrain_to_move_in_y;
   eq_steps_count_ = 0;
 
   /* Refine parameters */
@@ -142,14 +143,18 @@ void RigidFilament::Integrate() {
     orientation_[i] += du[i] * delta_ / gamma_rot_;
   }
   normalize_vector(orientation_, n_dim_);
-  if (!zero_temperature_) {
+  if (!zero_temperature_ && !constrain_to_move_in_y_) {
     // Add the random displacement dr(t)
     AddRandomDisplacement();
     // Update the orientation due to torques and random rotation
     AddRandomReorientation();
   }
-  // double f_mag = sqrt(dot_product(n_dim_, force_, force_));
-  // printf("f_mag = %f\n", f_mag);
+  //With constrain_to_move_in_y on filaments don't roate and only diffuse in
+  //the y direction
+	if (!zero_temperature_ && constrain_to_move_in_y_) {
+     //Add the random displacement dr(t)
+     AddRandomYDisplacement();
+  }
 
   UpdatePeriodic();
   UpdateSitePositions();
@@ -174,8 +179,17 @@ void RigidFilament::AddRandomDisplacement() {
     for (int i = 0; i < n_dim_; ++i)
       position_[i] += mag * body_frame_[n_dim_ * j + i];
   }
+  
   // Handle the random orientation update after updating orientation from
   // interaction torques
+}
+
+//With constrain_to_move_in_y on filaments only diffuse in the y 
+//direction and don't rotate
+void RigidFilament::AddRandomYDisplacement() {
+	double mag = rng_.RandomNormal(diffusion_par_);
+  mag = rng_.RandomNormal(diffusion_perp_);
+  position_[1] += mag;
 }
 
 /* The orientation update is also from Yu-Guo Tao,
@@ -246,7 +260,12 @@ double const RigidFilament::GetVolume() {
 }
 
 void RigidFilament::UpdatePosition() {
-  ApplyForcesTorques();
+	if (!constrain_to_move_in_y_){
+		ApplyForcesTorques();
+	}
+	else{
+		ApplyForcesTorquesYOnly();
+	}
   if (!params_->on_midstep && !sparams_->stationary_flag)
     Integrate();
   eq_steps_count_++;
@@ -299,6 +318,19 @@ void RigidFilament::ApplyForcesTorques() {
   for (int i = 0; i < 3; ++i) {
     force_[i] += force[i];
     torque_[i] += torque[i];
+  }
+}
+//With constrain_to_move_in_y flag on, filaments don't rotate and only move in the y direction
+void RigidFilament::ApplyForcesTorquesYOnly() {
+  const double *force = bonds_.back().GetForce();
+  for (int i = 0; i < 3; ++i) {
+    if (i==1){
+			force_[i] += force[1];
+    }
+		else{
+      force_[i]=0;
+		}
+    torque_[i] = 0;
   }
 }
 

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -151,7 +151,7 @@ void RigidFilament::Integrate() {
   }
   //With constrain_to_move_in_y on filaments don't roate and only diffuse in
   //the y direction
-	if (!zero_temperature_ && constrain_to_move_in_y_) {
+  if (!zero_temperature_ && constrain_to_move_in_y_) {
      //Add the random displacement dr(t)
      AddRandomYDisplacement();
   }
@@ -187,7 +187,7 @@ void RigidFilament::AddRandomDisplacement() {
 //With constrain_to_move_in_y on filaments only diffuse in the y 
 //direction and don't rotate
 void RigidFilament::AddRandomYDisplacement() {
-	double mag = rng_.RandomNormal(diffusion_par_);
+  double mag = rng_.RandomNormal(diffusion_par_);
   mag = rng_.RandomNormal(diffusion_perp_);
   position_[1] += mag;
 }
@@ -260,12 +260,12 @@ double const RigidFilament::GetVolume() {
 }
 
 void RigidFilament::UpdatePosition() {
-	if (!constrain_to_move_in_y_){
-		ApplyForcesTorques();
-	}
-	else{
-		ApplyForcesTorquesYOnly();
-	}
+  if (!constrain_to_move_in_y_){
+    ApplyForcesTorques();
+  }
+  else {
+    ApplyForcesTorquesYOnly();
+  }
   if (!params_->on_midstep && !sparams_->stationary_flag)
     Integrate();
   eq_steps_count_++;
@@ -325,11 +325,11 @@ void RigidFilament::ApplyForcesTorquesYOnly() {
   const double *force = bonds_.back().GetForce();
   for (int i = 0; i < 3; ++i) {
     if (i==1){
-			force_[i] += force[1];
+      force_[i] += force[1];
     }
-		else{
+    else {
       force_[i]=0;
-		}
+    }
     torque_[i] = 0;
   }
 }


### PR DESCRIPTION
## Description of changes
Added constrain_motion_to_y flag, with flag on rigid filaments only move in the y direction.  The constrain_motion_flag flag seems it was intended to do this, but it isn't working and adding a new flag was easier than fixing the old flag.

## Changes in behavior
With flag off there is no change to behavior.

