### PR TITLE
Stationary until

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -130,6 +130,8 @@ species:                             # Shared parameters used for all species.
   n_posit: [100, int]                # Frequency used for generating posit file information.
   n_spec: [100, int]                 # Frequency used for generating spec file information.
   stationary_flag: [false, bool]     # If true, members will not move regardless of forces on them.
+  stationary_until: [-1, int]        # Species wont move until specified time step, overwritten by
+                                     # stationary flag, currently only implemented for rigid/flexable filaments 
 
 rigid_filament:
   max_length: [500, double]          # maximum filament length. also used for dynamic instability.
@@ -198,7 +200,7 @@ filament:                            # Parameters unique to filament class of ob
   spiral_analysis: [false, bool]  # runs analysis on spiral filaments in analysis mode
   spiral_number_fail_condition: [0, double] # when spiral_init_flag is on, terminates simulation 
                                             # when spiral number of a filament is < value.
-
+  stationary_until: [-1, int]     # Filiments w 
   orientation_corr_analysis: [false, bool] # post-process analysis of orientation correlation function.
   orientation_corr_n_steps: [1000, int] # number of steps to measure orientation correlation, defines
                                         # interval over which to average.

--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -200,7 +200,6 @@ filament:                            # Parameters unique to filament class of ob
   spiral_analysis: [false, bool]  # runs analysis on spiral filaments in analysis mode
   spiral_number_fail_condition: [0, double] # when spiral_init_flag is on, terminates simulation 
                                             # when spiral number of a filament is < value.
-  stationary_until: [-1, int]     # Filiments w 
   orientation_corr_analysis: [false, bool] # post-process analysis of orientation correlation function.
   orientation_corr_n_steps: [1000, int] # number of steps to measure orientation correlation, defines
                                         # interval over which to average.

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -13,6 +13,7 @@
   default_config["species"]["n_posit"] = "100";
   default_config["species"]["n_spec"] = "100";
   default_config["species"]["stationary_flag"] = "false";
+  default_config["species"]["stationary_until"] = "-1";
   default_config["rigid_filament"]["max_length"] = "500";
   default_config["rigid_filament"]["min_length"] = "5";
   default_config["rigid_filament"]["constrain_motion_flag"] = "false";
@@ -55,6 +56,7 @@
   default_config["filament"]["spiral_init_flag"] = "false";
   default_config["filament"]["spiral_analysis"] = "false";
   default_config["filament"]["spiral_number_fail_condition"] = "0";
+  default_config["filament"]["stationary_until"] = "-1";
   default_config["filament"]["orientation_corr_analysis"] = "false";
   default_config["filament"]["orientation_corr_n_steps"] = "1000";
   default_config["filament"]["crossing_analysis"] = "false";

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -20,6 +20,7 @@ template <unsigned char S> struct species_parameters {
   int n_posit = 100;
   int n_spec = 100;
   bool stationary_flag = false;
+  int stationary_until = -1;
   virtual ~species_parameters() {}
 };
 
@@ -76,6 +77,7 @@ struct species_parameters<species_id::filament>
   bool spiral_init_flag = false;
   bool spiral_analysis = false;
   double spiral_number_fail_condition = 0;
+  int stationary_until = -1;
   bool orientation_corr_analysis = false;
   int orientation_corr_n_steps = 1000;
   bool crossing_analysis = false;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -209,6 +209,8 @@ void parse_species_base_params(species_base_parameters &params,
         params.n_spec = jt->second.as<int>();
         } else if (param_name.compare("stationary_flag")==0) {
         params.stationary_flag = jt->second.as<bool>();
+        } else if (param_name.compare("stationary_until")==0) {
+        params.stationary_until = jt->second.as<int>();
         } else {
           Logger::Warning("Species base parameter %s not recognized!", param_name.c_str());
         }
@@ -256,6 +258,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("max_length")==0) {
       params.max_length = jt->second.as<double>();
       } else if (param_name.compare("min_length")==0) {
@@ -307,6 +311,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("packing_fraction")==0) {
       params.packing_fraction = jt->second.as<double>();
       } else if (param_name.compare("persistence_length")==0) {
@@ -379,6 +385,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.spiral_analysis = jt->second.as<bool>();
       } else if (param_name.compare("spiral_number_fail_condition")==0) {
       params.spiral_number_fail_condition = jt->second.as<double>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("orientation_corr_analysis")==0) {
       params.orientation_corr_analysis = jt->second.as<bool>();
       } else if (param_name.compare("orientation_corr_n_steps")==0) {
@@ -496,6 +504,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("driving_factor")==0) {
       params.driving_factor = jt->second.as<double>();
       } else if (param_name.compare("driving_torque")==0) {
@@ -559,6 +569,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("diffusion_analysis")==0) {
       params.diffusion_analysis = jt->second.as<bool>();
       } else if (param_name.compare("n_diffusion_samples")==0) {
@@ -602,6 +614,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("n_filaments_bud")==0) {
       params.n_filaments_bud = jt->second.as<int>();
       } else if (param_name.compare("n_filaments_mother")==0) {
@@ -657,6 +671,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("concentration")==0) {
       params.concentration = jt->second.as<double>();
       } else if (param_name.compare("begin_with_bound_crosslinks")==0) {
@@ -817,6 +833,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.n_spec = jt->second.as<int>();
       } else if (param_name.compare("stationary_flag")==0) {
       params.stationary_flag = jt->second.as<bool>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("component")==0) {
       params.component = jt->second.as<std::string>();
       } else if (param_name.compare("concentration")==0) {

--- a/src/filament.cpp
+++ b/src/filament.cpp
@@ -412,7 +412,7 @@ double const Filament::GetVolume() {
 
 void Filament::UpdatePosition() {
   ApplyForcesTorques();
-  if (!sparams_->stationary_flag)
+  if (!sparams_->stationary_flag  && (sparams_->stationary_until)<eq_steps_)
     Integrate();
   UpdateAvgPosition();
   DynamicInstability();

--- a/src/rigid_filament.cpp
+++ b/src/rigid_filament.cpp
@@ -266,7 +266,7 @@ void RigidFilament::UpdatePosition() {
   else {
     ApplyForcesTorquesYOnly();
   }
-  if (!params_->on_midstep && !sparams_->stationary_flag)
+  if (!params_->on_midstep && !sparams_->stationary_flag && (sparams_->stationary_until)<eq_steps_count_)
     Integrate();
   eq_steps_count_++;
 }


### PR DESCRIPTION
## Description of changes
Added stationary_until flag, filaments won't move until specified timestep. Can be used to allow crosslinkers to connect filaments before they drift apart. Currently only works with filaments and rigid filaments.

## Changes in behavior
No changes with flag off
