### PR TITLE
No crossing

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -315,6 +315,7 @@ crosslink:                          # Parameters specific to crosslinks.
                                          # crosslinks in solution.
   bind_site_density: [1, double] # The binding site density of an object that crosslinker
                                          # ends bind to 
+  cant_cross: [false, bool]         # If set to true crosslinkers binding the same two filaments cant cross 
   static_flag: [false, bool]        # Flag for setting one crosslinker head to be fixed in space
   diffusion_s: [0, double]          # Diffusion coefficient for singly bound crosslinks
   diffusion_d: [0, double]          # Diffusion coefficient for doubly bound crosslinks

--- a/include/cglass/anchor.hpp
+++ b/include/cglass/anchor.hpp
@@ -132,6 +132,8 @@ class Anchor : public Object {
   double const GetBondLambda();
   Object *GetNeighbor(int i_neighbor);
   Sphere *GetSphereNeighbor(int i_neighbor);
+  double GetRecS();
+  int GetPCID();
   Rod *GetRodNeighbor(int i_neighbor);
   const int GetNNeighbors() const;
   const int GetNNeighborsSphere() const;

--- a/include/cglass/crosslink.hpp
+++ b/include/cglass/crosslink.hpp
@@ -48,8 +48,7 @@ private:
   void UpdateXlinkState();
   double *obj_size_ = nullptr;
   Tracker *tracker_ = nullptr;
-  int i_ = 0;
-  bool* global_check_for_cross_ = nullptr;
+ bool* global_check_for_cross_ = nullptr;
 
 public:
   Crosslink(unsigned long seed);

--- a/include/cglass/crosslink.hpp
+++ b/include/cglass/crosslink.hpp
@@ -48,10 +48,13 @@ private:
   void UpdateXlinkState();
   double *obj_size_ = nullptr;
   Tracker *tracker_ = nullptr;
+  int i_ = 0;
+  bool* global_check_for_cross_ = nullptr;
 
 public:
   Crosslink(unsigned long seed);
   void Init(crosslink_parameters *sparams);
+  void SetGlobalCheckForCross(bool* check);
   void InitInteractionEnvironment(LookupTable *lut, Tracker *tracker, 
                                   std::map<Sphere *, std::pair<std::vector<double>, 
                                   std::vector<Anchor*> > > *bound_curr);
@@ -61,6 +64,8 @@ public:
   void UpdateCrosslinkForces();
   void UpdateCrosslinkPositions();
   void GetAnchors(std::vector<Object *> &ixors);
+  std::vector<double> GetAnchorS();
+  std::vector<int> GetReceptorIDs();
   int GetLastBound();
   bool ReturnCheckForCross();
   void SetCheckForCross();

--- a/include/cglass/crosslink.hpp
+++ b/include/cglass/crosslink.hpp
@@ -33,6 +33,8 @@ private:
   double polar_affinity_;
   bool use_bind_file_;
   int bound_anchor_ = 0; // Index of anchor that is bound if Singly
+  int last_bound_ = 0;
+  bool check_for_cross = false;
   std::map<Sphere *, std::pair<std::vector<double>, std::vector<Anchor*> > > *bound_curr_ = nullptr;
   std::vector<std::map<std::string, bind_params> > *bind_param_map_ = nullptr;
   double *bind_rate_ = nullptr;
@@ -59,6 +61,10 @@ public:
   void UpdateCrosslinkForces();
   void UpdateCrosslinkPositions();
   void GetAnchors(std::vector<Object *> &ixors);
+  int GetLastBound();
+  bool ReturnCheckForCross();
+  void SetCheckForCross();
+  void UnbindCrossing();
   void GetInteractors(std::vector<Object *> &ixors);
   void Draw(std::vector<graph_struct *> &graph_array);
   void SetDoubly();

--- a/include/cglass/crosslink.hpp
+++ b/include/cglass/crosslink.hpp
@@ -64,7 +64,7 @@ public:
   void UpdateCrosslinkPositions();
   void GetAnchors(std::vector<Object *> &ixors);
   std::vector<double> GetAnchorS();
-  std::vector<int> GetReceptorIDs();
+  std::vector<int> GetReceptorPCIDs();
   int GetLastBound();
   bool ReturnCheckForCross();
   void SetCheckForCross();

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -4,9 +4,6 @@
 #include "output_manager.hpp"
 #include "species_factory.hpp"
 
-
-
-
 class CrosslinkOutputManager : public OutputManagerBase<CrosslinkSpecies> {
   /* Do not write thermo - base output manager will handle that */
   void WriteThermo() {}
@@ -29,7 +26,7 @@ class CrosslinkManager {
   bool global_check_for_cross = false;
 
  public:
- void Init(system_parameters *params, SpaceBase *space, Tracker *tracker,
+  void Init(system_parameters *params, SpaceBase *space, Tracker *tracker,
             std::vector<Object *> *objs);
   void GetInteractors(std::vector<Object *> &ixors);
   void UpdateCrosslinks();

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -24,6 +24,7 @@ class CrosslinkManager {
   SpaceBase *space_;
   Tracker *tracker_ = nullptr;
   bool global_check_for_cross = false;
+  bool same_microtubules = true;
 
  public:
   void Init(system_parameters *params, SpaceBase *space, Tracker *tracker,

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -31,6 +31,7 @@ class CrosslinkManager {
   void UpdateCrosslinks();
   void UpdateObjsSize();
   bool CheckUpdate();
+  void CheckForCross();
   void Clear();
   void Draw(std::vector<graph_struct *> &graph_array);
   void AddNeighborToAnchor(Object *anchor, Object *neighbor);

--- a/include/cglass/crosslink_manager.hpp
+++ b/include/cglass/crosslink_manager.hpp
@@ -4,6 +4,9 @@
 #include "output_manager.hpp"
 #include "species_factory.hpp"
 
+
+
+
 class CrosslinkOutputManager : public OutputManagerBase<CrosslinkSpecies> {
   /* Do not write thermo - base output manager will handle that */
   void WriteThermo() {}
@@ -23,9 +26,10 @@ class CrosslinkManager {
   std::map<Sphere *, std::pair<std::vector<double>, std::vector<Anchor*> > > bound_curr_;
   SpaceBase *space_;
   Tracker *tracker_ = nullptr;
+  bool global_check_for_cross = false;
 
  public:
-  void Init(system_parameters *params, SpaceBase *space, Tracker *tracker,
+ void Init(system_parameters *params, SpaceBase *space, Tracker *tracker,
             std::vector<Object *> *objs);
   void GetInteractors(std::vector<Object *> &ixors);
   void UpdateCrosslinks();

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -4,6 +4,7 @@
 #include "crosslink.hpp"
 #include "species.hpp"
 #include <KMC/kmc.hpp>
+#include "receptor_species.hpp"
 
 typedef std::vector<std::pair<std::vector<Crosslink>::iterator,
                               std::vector<Crosslink>::iterator>>
@@ -48,6 +49,7 @@ private:
   void UpdateBoundCrosslinkPositions();
   void ApplyCrosslinkTetherForces();
   std::pair<Object*, int> GetRandomObject();
+  bool* global_check_for_cross_;
 
 public:
   CrosslinkSpecies(unsigned long seed);
@@ -57,6 +59,7 @@ public:
                                   std::map<Sphere *, std::pair<std::vector<double>, 
                                   std::vector<Anchor*> > > *bound_curr);
   void TestKMCStepSize();
+  void SetCheckForCrossPointer(bool* check);
   void GetInteractors(std::vector<Object *> &ixors);
   void UpdatePositions();
   void UpdateBindRate();
@@ -70,9 +73,11 @@ public:
   void GetAnchorInteractors(std::vector<Object *> &ixors);
   void ReadSpecs();
   void InsertCrosslinks();
+  Crosslink* GetCrosslink(int i); 
   const int GetDoublyBoundCrosslinkNumber() const;
   const double GetConcentration() const;
   const double GetRCutoff() const;
+  const double *const ReturnMembers(); 
 };
 
 #endif

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -77,7 +77,6 @@ public:
   const int GetDoublyBoundCrosslinkNumber() const;
   const double GetConcentration() const;
   const double GetRCutoff() const;
-  const double *const ReturnMembers(); 
 };
 
 #endif

--- a/include/cglass/crosslink_species.hpp
+++ b/include/cglass/crosslink_species.hpp
@@ -4,7 +4,6 @@
 #include "crosslink.hpp"
 #include "species.hpp"
 #include <KMC/kmc.hpp>
-#include "receptor_species.hpp"
 
 typedef std::vector<std::pair<std::vector<Crosslink>::iterator,
                               std::vector<Crosslink>::iterator>>
@@ -59,7 +58,7 @@ public:
                                   std::map<Sphere *, std::pair<std::vector<double>, 
                                   std::vector<Anchor*> > > *bound_curr);
   void TestKMCStepSize();
-  void SetCheckForCrossPointer(bool* check);
+  void SetGlobalCheckForCrossPointer(bool* check);
   void GetInteractors(std::vector<Object *> &ixors);
   void UpdatePositions();
   void UpdateBindRate();

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -56,7 +56,6 @@
   default_config["filament"]["spiral_init_flag"] = "false";
   default_config["filament"]["spiral_analysis"] = "false";
   default_config["filament"]["spiral_number_fail_condition"] = "0";
-  default_config["filament"]["stationary_until"] = "-1";
   default_config["filament"]["orientation_corr_analysis"] = "false";
   default_config["filament"]["orientation_corr_n_steps"] = "1000";
   default_config["filament"]["crossing_analysis"] = "false";
@@ -145,6 +144,7 @@
   default_config["crosslink"]["use_binding_volume"] = "true";
   default_config["crosslink"]["infinite_reservoir_flag"] = "false";
   default_config["crosslink"]["bind_site_density"] = "1";
+  default_config["crosslink"]["cant_cross"] = "false";
   default_config["crosslink"]["static_flag"] = "false";
   default_config["crosslink"]["diffusion_s"] = "0";
   default_config["crosslink"]["diffusion_d"] = "0";

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -56,6 +56,7 @@
   default_config["filament"]["spiral_init_flag"] = "false";
   default_config["filament"]["spiral_analysis"] = "false";
   default_config["filament"]["spiral_number_fail_condition"] = "0";
+  default_config["filament"]["stationary_until"] = "-1";
   default_config["filament"]["orientation_corr_analysis"] = "false";
   default_config["filament"]["orientation_corr_n_steps"] = "1000";
   default_config["filament"]["crossing_analysis"] = "false";

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -77,7 +77,6 @@ struct species_parameters<species_id::filament>
   bool spiral_init_flag = false;
   bool spiral_analysis = false;
   double spiral_number_fail_condition = 0;
-  int stationary_until = -1;
   bool orientation_corr_analysis = false;
   int orientation_corr_n_steps = 1000;
   bool crossing_analysis = false;
@@ -168,6 +167,7 @@ struct species_parameters<species_id::crosslink>
   bool use_binding_volume = true;
   bool infinite_reservoir_flag = false;
   double bind_site_density = 1;
+  bool cant_cross = false;
   bool static_flag = false;
   double diffusion_s = 0;
   double diffusion_d = 0;

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -77,6 +77,7 @@ struct species_parameters<species_id::filament>
   bool spiral_init_flag = false;
   bool spiral_analysis = false;
   double spiral_number_fail_condition = 0;
+  int stationary_until = -1;
   bool orientation_corr_analysis = false;
   int orientation_corr_n_steps = 1000;
   bool crossing_analysis = false;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -385,8 +385,6 @@ species_base_parameters *parse_species_params(std::string sid,
       params.spiral_analysis = jt->second.as<bool>();
       } else if (param_name.compare("spiral_number_fail_condition")==0) {
       params.spiral_number_fail_condition = jt->second.as<double>();
-      } else if (param_name.compare("stationary_until")==0) {
-      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("orientation_corr_analysis")==0) {
       params.orientation_corr_analysis = jt->second.as<bool>();
       } else if (param_name.compare("orientation_corr_n_steps")==0) {
@@ -683,6 +681,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.infinite_reservoir_flag = jt->second.as<bool>();
       } else if (param_name.compare("bind_site_density")==0) {
       params.bind_site_density = jt->second.as<double>();
+      } else if (param_name.compare("cant_cross")==0) {
+      params.cant_cross = jt->second.as<bool>();
       } else if (param_name.compare("static_flag")==0) {
       params.static_flag = jt->second.as<bool>();
       } else if (param_name.compare("diffusion_s")==0) {

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -385,6 +385,8 @@ species_base_parameters *parse_species_params(std::string sid,
       params.spiral_analysis = jt->second.as<bool>();
       } else if (param_name.compare("spiral_number_fail_condition")==0) {
       params.spiral_number_fail_condition = jt->second.as<double>();
+      } else if (param_name.compare("stationary_until")==0) {
+      params.stationary_until = jt->second.as<int>();
       } else if (param_name.compare("orientation_corr_analysis")==0) {
       params.orientation_corr_analysis = jt->second.as<bool>();
       } else if (param_name.compare("orientation_corr_n_steps")==0) {

--- a/include/cglass/species.hpp
+++ b/include/cglass/species.hpp
@@ -64,9 +64,6 @@ public:
   virtual Object* GetMember(int i) { 
     return &members_[i];
   }
-  virtual int GetMemberNum() {
-    return sizeof(members_)/sizeof(members_[0]);
-  }
   virtual void AddMember();
   virtual void AddMember(T newmem);
   virtual void PopMember();

--- a/include/cglass/species.hpp
+++ b/include/cglass/species.hpp
@@ -64,6 +64,9 @@ public:
   virtual Object* GetMember(int i) { 
     return &members_[i];
   }
+  virtual int GetMemberNum() {
+    return sizeof(members_)/sizeof(members_[0]);
+  }
   virtual void AddMember();
   virtual void AddMember(T newmem);
   virtual void PopMember();

--- a/include/cglass/sphere.hpp
+++ b/include/cglass/sphere.hpp
@@ -12,6 +12,7 @@ class Sphere : public Object {
       Sphere* prev_r_ = nullptr; // The previous receptor (in - direction) on the filament 
       Sphere* next_r_ = nullptr; // The next receptor (in + direction) on the filament
       Object* pc_object_ = nullptr; // point cover object sphere is on
+      double s_ = 0; //how far the sphere is along a filament
       double step_size_ = 0;
     public:
       Sphere(unsigned long seed);
@@ -20,6 +21,8 @@ class Sphere : public Object {
       void SetPCObjectForSphere(Object* pc_object);
       void SetStepSize(double step_size);
       double GetStepSize();
+      void SetSphereS(double s_);
+      double GetSphereS();
       Object* GetPCObjectForSphere();
       Sphere* GetPlusNeighbor();
       Sphere* GetMinusNeighbor();

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -726,6 +726,7 @@ int const Anchor::GetBoundOID() {
   else return -1;
 }
 
+//Get ID for point cover anchor is on
 int Anchor::GetPCID() {
   if (sphere_) {
     return (sphere_ ->GetPCObjectForSphere()) -> GetOID();
@@ -764,6 +765,7 @@ Sphere *Anchor::GetSphereNeighbor(int i_neighbor) {
   return neighbors_.GetSphereNeighbor(i_neighbor);
 }
 
+//Get how far the anchor's receptor is on the filament (currently only set up for parallel and antiparallel) 
 double Anchor::GetRecS() {
   if (sphere_) {    
     double const *const rod_orientation_ = (sphere_ ->GetPCObjectForSphere()) -> GetOrientation();

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -726,6 +726,15 @@ int const Anchor::GetBoundOID() {
   else return -1;
 }
 
+int Anchor::GetPCID() {
+  if (sphere_) {
+    return (sphere_ ->GetPCObjectForSphere()) -> GetOID();
+  } else {
+    Logger::Error("Try to get PC ID for a non-receptor");
+    return 0; 
+  }
+}
+
 /* Temporary function for setting bound state for singly-bound crosslinks,
    in order to get them to draw while not technically bound to a bond
    ( e.g. rod_ -> null ) */
@@ -753,6 +762,23 @@ Object *Anchor::GetNeighbor(int i_neighbor) {
 
 Sphere *Anchor::GetSphereNeighbor(int i_neighbor) {
   return neighbors_.GetSphereNeighbor(i_neighbor);
+}
+
+double Anchor::GetRecS() {
+  if (sphere_) {
+    
+    double const *const rod_orientation_ = (sphere_ ->GetPCObjectForSphere()) -> GetOrientation();
+    if (rod_orientation_[0]>0) {
+      return sphere_ -> GetSphereS();
+    }
+    else {
+      double s = sphere_-> GetSphereS();
+      return -s;
+    }
+  } else {
+    Logger::Error("Anchor is not attatched to Sphere");
+  return 0;
+  }
 }
 
 Rod *Anchor::GetRodNeighbor(int i_neighbor) {

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -730,7 +730,7 @@ int Anchor::GetPCID() {
   if (sphere_) {
     return (sphere_ ->GetPCObjectForSphere()) -> GetOID();
   } else {
-    Logger::Error("Try to get PC ID for a non-receptor");
+    Logger::Error("Tried to get PC ID for a non-receptor");
     return 0; 
   }
 }
@@ -765,8 +765,7 @@ Sphere *Anchor::GetSphereNeighbor(int i_neighbor) {
 }
 
 double Anchor::GetRecS() {
-  if (sphere_) {
-    
+  if (sphere_) {    
     double const *const rod_orientation_ = (sphere_ ->GetPCObjectForSphere()) -> GetOrientation();
     if (rod_orientation_[0]>0) {
       return sphere_ -> GetSphereS();

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -177,9 +177,40 @@ void Crosslink::SinglyKMC() {
       SetDoubly();
       Logger::Trace("Crosslink %d became doubly bound to obj %d", GetOID(),
                   bind_obj->GetOID());
+      if (sparams_ -> cant_cross == true) {
+        check_for_cross = true;
+        last_bound_ = (int)!bound_anchor_;
+      }
     }
   }
 }
+
+//If a crosslinker was bound during this step it is flaged to check to see if 
+//it is crossing another crosslinker
+bool Crosslink::ReturnCheckForCross() {
+  return check_for_cross;
+}
+
+//After a crosslinker is checked if its crossing set check_for_cross back to false
+void Crosslink::SetCheckForCross() {
+  check_for_cross = false;
+}
+
+//Get the most recently bound anchor
+int Crosslink::GetLastBound() {
+  return last_bound_;
+}
+
+void Crosslink::UnbindCrossing() {
+  Logger::Trace("Crosslinker %f came unbound because it was crossing another crosslinker", GetOID());
+  int head_activate = last_bound_;
+  ClearNeighbors();
+  UpdateXlinkState();
+  tracker_ -> UnbindDS();
+  anchors_[head_activate].Unbind();
+  SetSingly((int)!head_activate);
+}
+  
 
 /* Perform kinetic monte carlo step of protein with 2 heads of protein
  * object attached. */

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -177,11 +177,16 @@ void Crosslink::SinglyKMC() {
       SetDoubly();
       Logger::Trace("Crosslink %d became doubly bound to obj %d", GetOID(),
                   bind_obj->GetOID());
+      //If crosslinkers can't cross check if newly bound crosslinker is crossing
       if (sparams_ -> cant_cross == true) {
         check_for_cross = true;
         last_bound_ = (int)!bound_anchor_;
-        *global_check_for_cross_ = true;
-     }
+        if (*global_check_for_cross_ == true) {
+          Logger::Error("Two crosslinks bound during same time step");
+        } else {
+          *global_check_for_cross_ = true;
+        }
+      }
     }
   }
 }
@@ -202,11 +207,13 @@ void Crosslink::SetGlobalCheckForCross(bool* global_check_for_cross){
   global_check_for_cross_ = global_check_for_cross;
 }
 
-//Get the most recently bound anchor
+//Get index of most recently bound anchor (if crosslinker unbinds do to crosslinking 
+//most recently bound anchor needs to unbind)
 int Crosslink::GetLastBound() {
   return last_bound_;
 }
 
+//Unbind anchor if unbinding is due to crosslinkers crossing
 void Crosslink::UnbindCrossing() {
   Logger::Trace("Crosslinker %f came unbound because it was crossing another crosslinker", GetOID());
   int head_activate = last_bound_;
@@ -275,6 +282,7 @@ void Crosslink::GetInteractors(std::vector<Object *> &ixors) {
   }
 }
 
+//Get how far anchors are along the filaments
 std::vector<double> Crosslink::GetAnchorS() {
   std::vector<double> s_values_;
   s_values_.push_back(anchors_[0].GetRecS());
@@ -282,7 +290,8 @@ std::vector<double> Crosslink::GetAnchorS() {
   return s_values_;
 }
 
-std::vector<int> Crosslink::GetReceptorIDs() {
+//Get the IDs of the filaments that the receptors the anchors are connected to are connected to
+std::vector<int> Crosslink::GetReceptorPCIDs() {
   std::vector<int> rec_ids_;
   rec_ids_.push_back(anchors_[0].GetPCID());  
   rec_ids_.push_back(anchors_[1].GetPCID()); 

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -180,7 +180,8 @@ void Crosslink::SinglyKMC() {
       if (sparams_ -> cant_cross == true) {
         check_for_cross = true;
         last_bound_ = (int)!bound_anchor_;
-      }
+        *global_check_for_cross_ = true;
+     }
     }
   }
 }
@@ -194,6 +195,11 @@ bool Crosslink::ReturnCheckForCross() {
 //After a crosslinker is checked if its crossing set check_for_cross back to false
 void Crosslink::SetCheckForCross() {
   check_for_cross = false;
+  *global_check_for_cross_ = false;
+}
+
+void Crosslink::SetGlobalCheckForCross(bool* global_check_for_cross){
+  global_check_for_cross_ = global_check_for_cross;
 }
 
 //Get the most recently bound anchor
@@ -209,6 +215,7 @@ void Crosslink::UnbindCrossing() {
   tracker_ -> UnbindDS();
   anchors_[head_activate].Unbind();
   SetSingly((int)!head_activate);
+  SetCheckForCross();
 }
   
 
@@ -247,6 +254,7 @@ void Crosslink::DoublyKMC() {
                   anchors_[head_activate].GetBoundOID());
     anchors_[head_activate].Unbind();
     SetSingly((int)!head_activate);
+    SetCheckForCross();
   }
 }
 
@@ -266,6 +274,20 @@ void Crosslink::GetInteractors(std::vector<Object *> &ixors) {
     ixors.push_back(&anchors_[bound_anchor_]);
   }
 }
+
+std::vector<double> Crosslink::GetAnchorS() {
+  std::vector<double> s_values_;
+  s_values_.push_back(anchors_[0].GetRecS());
+  s_values_.push_back(anchors_[1].GetRecS());
+  return s_values_;
+}
+
+std::vector<int> Crosslink::GetReceptorIDs() {
+  std::vector<int> rec_ids_;
+  rec_ids_.push_back(anchors_[0].GetPCID());  
+  rec_ids_.push_back(anchors_[1].GetPCID()); 
+  return rec_ids_;
+} 
 
 void Crosslink::ClearNeighbors() { anchors_[bound_anchor_].ClearNeighbors(); }
 

--- a/src/crosslink_manager.cpp
+++ b/src/crosslink_manager.cpp
@@ -90,7 +90,6 @@ void CrosslinkManager::CheckForCross() {
   //Sorry this is a mess to look at, this is going over over crosslink in every species 
   //and comparing it to every other crosslink in every species to see if the crosslinks
   //are crossing
-  bool same_microtubles;
   for (auto spec_one = xlink_species_.begin(); spec_one != xlink_species_.end(); ++spec_one) {
   int member_num_ = (*spec_one) -> GetNMembers(); 
     for (int i = 0; i <= (member_num_-1); i++) {
@@ -101,29 +100,31 @@ void CrosslinkManager::CheckForCross() {
           int member_num_two_ = (*spec_two) -> GetNMembers();  
           for (int j = 0; j <= (member_num_two_-1); j++) {
             Crosslink* link_two = (*spec_two) -> GetCrosslink(j);
-              //If link two is double bound and the crosslinkers aren't the same crosslinker
+            //If link two is double bound and the crosslinkers aren't the same crosslinker
             if(link_two -> IsDoubly() && link_one -> GetOID() != link_two -> GetOID()) {
               //Get how far the crosslinker anchors are along the filament
               std::vector<double> link_one_s = link_one -> GetAnchorS();
               std::vector<double> link_two_s = link_two -> GetAnchorS();
-              std::vector<int> rec_ids_one = link_one -> GetReceptorIDs();
-              std::vector<int> rec_ids_two = link_two -> GetReceptorIDs();
-              //If same index deosn't refer to sites on the same filament switch indexs so we are comparing same microtubule
+              //Get the IDs of the PCs crosslink one is attatched to
+              std::vector<int> rec_ids_one = link_one -> GetReceptorPCIDs();
+              //Get the IDs of the PCs crosslink two is attatched to
+              std::vector<int> rec_ids_two = link_two -> GetReceptorPCIDs();
+              //If same index doesn't refer to sites on the same filament switch indexs so 
+              //so the same index refers to anchors on the same microtubule
               if (rec_ids_one[0] != rec_ids_two[0]) {
                 std::swap(link_two_s[0], link_two_s[1]);
                 std::swap(rec_ids_two[0], rec_ids_two[1]);
               } 
-              //If the sites are still on different filaments then crosslinkers aren't binding the same microtubule 
+              //If the sites are still on different filaments then crosslinkers aren't binding the same microtubules
               if (rec_ids_one[0] == rec_ids_two[0]) {
                 same_microtubules = true;
               }
               else {
-              same_microtubules = false;
+                same_microtubules = false;
               }
-
+              //If crosslinkers are crossing and connected same microtubules, then unbind most rect crosslinker
               if (same_microtubules && ((link_one_s[0] > link_two_s[0] && link_one_s[1] < link_two_s[1]) 
                      || (link_one_s[0] < link_two_s[0] && link_one_s[1] > link_two_s[1]))) { 
-                Logger::Trace("Crosslinkers are crossing, %f, %f, %f, %f", link_one_s[0], link_one_s[1], link_two_s[0], link_two_s[1]);
                 link_one -> UnbindCrossing();
                 break;
               } else {
@@ -136,8 +137,6 @@ void CrosslinkManager::CheckForCross() {
     }
   }
 }
-
-
 
 // Loop over all spheres bound in the last dt. If multiple xlinks want to bind
 // to a site, roll based on their relative probabilities, and unbind all of the
@@ -157,7 +156,7 @@ void CrosslinkManager::Knockout() {
 void CrosslinkManager::InsertCrosslinks() {
   for (auto it = xlink_species_.begin(); it != xlink_species_.end(); ++it) {
     (*it)->InsertCrosslinks();
-    (*it)->SetCheckForCrossPointer(&global_check_for_cross);
+    (*it)->SetGlobalCheckForCrossPointer(&global_check_for_cross);
   } 
 }
 

--- a/src/crosslink_manager.cpp
+++ b/src/crosslink_manager.cpp
@@ -77,6 +77,37 @@ void CrosslinkManager::UpdateCrosslinks() {
     (*it)->UpdateBindRate();
   }
   Knockout();
+  CheckForCross();
+}
+
+//Check if any crosslinkers are crossing
+void CrosslinkManager::CheckForCross() {
+  bool crossing = false;
+  //Sorry this is a mess to look at, this is going over over crosslink in every species 
+  //and comparing it to every other crosslink in every species to see if the crosslinks
+  //are crossing
+  for (auto it = xlink_species_.begin(); it != xlink_species_.end(); ++it) {
+    for (auto mem = (*it)->members_.begin(); mem != (*it)->members_.end(); ++mem){
+      crossing = false;
+      if (mem->IsDoubly() && mem->ReturnCheckForCross()==true){
+        for (auto itTwo = xlink_species_.begin(); itTwo != xlink_species_.end(); ++itTwo) {
+          for (auto memTwo = (*itTwo)->members_.begin(); memTwo != (*itTwo)->members_.end(); ++memTwo){
+            //If 
+
+            if(mem-> IsDoubly() && memTwo->IsDoubly() && mem->GetOID()!=memTwo->GetOID()){
+              double const *const linkOne_pos = memOne -> GetPosition();
+              double const *const linkTwo_pos = memTwo -> GetPosition(); 
+              if( (memTwo->GetOneX()>mem->GetOneX() && memTwo->GetTwoX()<mem->GetTwoX()) 
+                     || (memTwo->GetOneX()<mem->GetOneX() && memTwo->GetTwoX()>mem->GetTwoX()) ){
+                bool crossing = true;
+                mem -> UnbindCrossing();
+              }
+            }
+          }    
+        }
+      }
+    }
+  }
 }
 
 // Loop over all spheres bound in the last dt. If multiple xlinks want to bind

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -688,9 +688,9 @@ const double CrosslinkSpecies::GetConcentration() const {
   return sparams_.concentration;
 }
 
-void CrosslinkSpecies::SetCheckForCrossPointer(bool* global_check_for_cross) {
+//Set pointer to global check for cross flag so individual crosslinks can change it
+void CrosslinkSpecies::SetGlobalCheckForCrossPointer(bool* global_check_for_cross) {
   global_check_for_cross_ = global_check_for_cross;
-  Logger::Warning("global set");
 }
 
 const double CrosslinkSpecies::GetRCutoff() const { return lut_.getLUCutoff(); }

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -411,6 +411,7 @@ std::pair <Object*, int> CrosslinkSpecies::GetRandomObject() {
 void CrosslinkSpecies::BindCrosslink() {
   AddMember();
   members_.back().AttachObjRandom(GetRandomObject());
+  members_.back().SetGlobalCheckForCross(global_check_for_cross_);
 }
 
 /* Return singly-bound anchors, for finding neighbors to bind to */
@@ -426,6 +427,10 @@ void CrosslinkSpecies::GetAnchorInteractors(std::vector<Object *> &ixors) {
   for (auto xlink = members_.begin(); xlink != members_.end(); ++xlink) {
     xlink->GetAnchors(ixors);
   }
+}
+
+Crosslink* CrosslinkSpecies::GetCrosslink(int i) {
+  return &members_[i];
 }
 
 void CrosslinkSpecies::UpdatePositions() {
@@ -682,4 +687,10 @@ const int CrosslinkSpecies::GetDoublyBoundCrosslinkNumber() const {
 const double CrosslinkSpecies::GetConcentration() const {
   return sparams_.concentration;
 }
+
+void CrosslinkSpecies::SetCheckForCrossPointer(bool* global_check_for_cross) {
+  global_check_for_cross_ = global_check_for_cross;
+  Logger::Warning("global set");
+}
+
 const double CrosslinkSpecies::GetRCutoff() const { return lut_.getLUCutoff(); }

--- a/src/receptor_species.cpp
+++ b/src/receptor_species.cpp
@@ -89,7 +89,6 @@ void ReceptorSpecies::AddMember() {
       members_.back().SetStepSize(spacing_);
       members_.back().SetPCSpecies(pc_species_);
       s_ += spacing_;
-      Logger::Warning("Setting i=%i and s=%f", i_, s_);
     }
   } else if (sparams_.insertion_type.compare("custom") != 0) {
     Logger::Error("Insertion type not recognized in receptor_species.cpp.");

--- a/src/receptor_species.cpp
+++ b/src/receptor_species.cpp
@@ -85,9 +85,11 @@ void ReceptorSpecies::AddMember() {
       members_.back().SetLocations(i_, s_);
       members_.back().SetPCObject(pc_species_->GetMember(i_));
       members_.back().SetPCObjectForSphere(pc_species_->GetMember(i_));
+      members_.back().SetSphereS(s_);
       members_.back().SetStepSize(spacing_);
       members_.back().SetPCSpecies(pc_species_);
       s_ += spacing_;
+      Logger::Warning("Setting i=%i and s=%f", i_, s_);
     }
   } else if (sparams_.insertion_type.compare("custom") != 0) {
     Logger::Error("Insertion type not recognized in receptor_species.cpp.");

--- a/src/sphere.cpp
+++ b/src/sphere.cpp
@@ -20,10 +20,12 @@ Object* Sphere::GetPCObjectForSphere() {
   return pc_object_;
 }
 
+//Set how long the sphere is along the filament
 void Sphere::SetSphereS(double s) {
   s_ = s;
 }
 
+//Get how far the sphere is along the filament
 double Sphere::GetSphereS() {
   return s_;
 }

--- a/src/sphere.cpp
+++ b/src/sphere.cpp
@@ -20,6 +20,14 @@ Object* Sphere::GetPCObjectForSphere() {
   return pc_object_;
 }
 
+void Sphere::SetSphereS(double s) {
+  s_ = s;
+}
+
+double Sphere::GetSphereS() {
+  return s_;
+}
+
 //Set the spacing between sites
 void Sphere::SetStepSize(double step_size) {
   step_size_ = step_size;


### PR DESCRIPTION
## Description of changes
Now can set can't_cross flag so crosslinkers can't cross

## Changes in behavior
With can't_cross flag set to false there should be no changes 

## Anything unresolved?
can't_cross flag is currently only set up for parallel or anti parallel microtubules
