### PR TITLE
Crosslinker diffusion fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dasteck/cglass:latest
+FROM jeffmm/simcore_base:latest
 WORKDIR /build
 RUN git clone --recursive --single-branch --branch master https://github.com/Betterton-Lab/C-GLASS.git . &&\
     ./install.sh -otI

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jeffmm/simcore_base:latest
+FROM dasteck/cglass:latest
 WORKDIR /build
 RUN git clone --recursive --single-branch --branch master https://github.com/Betterton-Lab/C-GLASS.git . &&\
     ./install.sh -otI

--- a/include/cglass/anchor.hpp
+++ b/include/cglass/anchor.hpp
@@ -90,8 +90,8 @@ class Anchor : public Object {
   void StepForward();
 
  public:
-  void SetDisToOtherPlus(double distance_);
-  void SetDisToOtherMinus(double distance_);
+  void SetLengthAtPlus(double distance_);
+  void SetLengthAtMinus(double distance_);
   void SetCrosslinkLength(double cl_length);
   Anchor(unsigned long seed);
   void Init(crosslink_parameters *sparams, int index);

--- a/include/cglass/anchor.hpp
+++ b/include/cglass/anchor.hpp
@@ -47,6 +47,7 @@ class Anchor : public Object {
   double partner_on_d_;
   double distance_to_plus_;
   double distance_to_minus_;
+  double cl_length_;
   double k_off_s_;
   double k_off_d_;
   double polar_affinity_;
@@ -91,6 +92,7 @@ class Anchor : public Object {
  public:
   void SetDisToOtherPlus(double distance_);
   void SetDisToOtherMinus(double distance_);
+  void SetCrosslinkLength(double cl_length);
   Anchor(unsigned long seed);
   void Init(crosslink_parameters *sparams, int index);
   void SetBindParamMap(std::vector<std::map<std::string, bind_params> >*);
@@ -141,6 +143,7 @@ class Anchor : public Object {
   const double GetOnRate() const;
   const double GetOffRate() const;
   const double GetMaxVelocity() const;
+  bool IsWalker();
   const double GetDiffusionConst() const;
   const double GetKickAmplitude() const;
   const double GetKonS() const;

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -207,11 +207,10 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
   double plus_diffusion = 0;
   double minus_diffusion = 0;
 
-
- //Calculating the chance the crosslinker will diffuse toward plus end
+  //Calculating the chance the crosslinker will diffuse toward plus end
   //If distance has been set to -1 this means the anchor is already at
   //the plus end of the microtubule and can't diffuse towards the plus end
-  if (distance_to_plus_ < 0) {
+  if (distance_to_plus_ = -1) {
     chance_forward_ = 0;
   }
   else {
@@ -230,7 +229,7 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
 
   //Calculate the chance the crosslinker will diffuse toward minus end
   //If at minus end chance to duffuse further is zero
-  if (distance_to_minus_ < 0) {
+  if (distance_to_minus_ = -1) {
     chance_back_ = 0;
   }
   else {
@@ -246,10 +245,10 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
     //k+ and k-
     chance_back_ = (minus_diffusion/pow(step_size_,2))*delta_;
 
- } 
+  } 
 
-if (chance_forward_>roll) {
-   StepForward();
+  if (chance_forward_>roll) {
+    StepForward();
   }
   if (chance_back_>(1-roll)) {
    StepBack();
@@ -261,13 +260,13 @@ if (chance_forward_>roll) {
 
 //Set the distance to the plus neighbor of the other head of
 //the crosslinker
-void Anchor::SetDisToOtherPlus(double distance) {
+void Anchor::SetLengthAtPlus(double distance) {
   distance_to_plus_ = distance;
 }
 
 //Set the distance to the plus neighbor of the other head of
 //the crosslinker
-void Anchor::SetDisToOtherMinus(double distance) {
+void Anchor::SetLengthAtMinus(double distance) {
   distance_to_minus_ = distance;
 }
 
@@ -928,7 +927,6 @@ bool Anchor::IsWalker () {
   bool walker = abs(GetMaxVelocity()) > input_tol ? true : false;
   return walker;
 }
-
 
 const double Anchor::GetDiffusionConst() const {
   switch (state_) {

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -210,7 +210,7 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
   //Calculating the chance the crosslinker will diffuse toward plus end
   //If distance has been set to -1 this means the anchor is already at
   //the plus end of the microtubule and can't diffuse towards the plus end
-  if (distance_to_plus_ = -1) {
+  if (distance_to_plus_ == -1) {
     chance_forward_ = 0;
   }
   else {
@@ -229,7 +229,7 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
 
   //Calculate the chance the crosslinker will diffuse toward minus end
   //If at minus end chance to duffuse further is zero
-  if (distance_to_minus_ = -1) {
+  if (distance_to_minus_ == -1) {
     chance_back_ = 0;
   }
   else {

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -202,15 +202,16 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
   double k = sparams_ -> k_spring;
   double r_l = sparams_ -> rest_length;
   //Calculate the current energy
-  double energy = 0.5 * k * pow((length_ - r_l), 2);   
+  double energy = 0.5 * k * pow((cl_length_ - r_l), 2);   
   double step_size_ = sphere_ -> GetStepSize();
   double plus_diffusion = 0;
   double minus_diffusion = 0;
- 
-  //Calculating the chance the crosslinker will diffuse toward plus end
+
+
+ //Calculating the chance the crosslinker will diffuse toward plus end
   //If distance has been set to -1 this means the anchor is already at
   //the plus end of the microtubule and can't diffuse towards the plus end
-  if (distance_to_plus_ = -1) {
+  if (distance_to_plus_ < 0) {
     chance_forward_ = 0;
   }
   else {
@@ -221,11 +222,15 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
     double boltz_factor_p = exp(-0.5 * e_change_to_p);
     //modify diffusion rate using Boltzmann factor
     plus_diffusion = boltz_factor_p * D;
+    //See  equation 7.30 and 7.31 from "Molecular motors: thermodynamics and
+    //the random walk" (Thomas et al. 2001). Equation rearranged to solve for
+    //k+ and k-
+    chance_forward_ = (plus_diffusion/pow(step_size_,2))*delta_;
   } 
 
   //Calculate the chance the crosslinker will diffuse toward minus end
   //If at minus end chance to duffuse further is zero
-  if (distance_to_minus_ = -1) {
+  if (distance_to_minus_ < 0) {
     chance_back_ = 0;
   }
   else {
@@ -236,18 +241,18 @@ void Anchor::DecideToStepCrosslink(double discrete_diffusion_) {
     double boltz_factor_m = exp(-0.5 * e_change_to_m);
     //modify diffusion rate using Boltzmann factor
     minus_diffusion = boltz_factor_m * D;
-  } 
+    //See  equation 7.30 and 7.31 from "Molecular motors: thermodynamics and
+    //the random walk" (Thomas et al. 2001). Equation rearranged to solve for
+    //k+ and k-
+    chance_back_ = (minus_diffusion/pow(step_size_,2))*delta_;
 
-  //See  equation 7.30 and 7.31 from "Molecular motors: thermodynamics and
-  //the random walk" (Thomas et al. 2001). Equation rearranged to solve for
-  //k+ and k-
-  chance_forward_ = (plus_diffusion/pow(step_size_,2))*delta_;
-  chance_back_ = (minus_diffusion/pow(step_size_,2))*delta_;
-  if (chance_forward_>roll) {
-    StepForward();
+ } 
+
+if (chance_forward_>roll) {
+   StepForward();
   }
   if (chance_back_>(1-roll)) {
-    StepBack();
+   StepBack();
   }
   if ( (chance_back_+chance_forward_) > 1) {
     Logger::Error("Chance of anchor hopping sites greater than one, time step far too large");
@@ -264,6 +269,10 @@ void Anchor::SetDisToOtherPlus(double distance) {
 //the crosslinker
 void Anchor::SetDisToOtherMinus(double distance) {
   distance_to_minus_ = distance;
+}
+
+void Anchor::SetCrosslinkLength(double cl_length) {
+  cl_length_ = cl_length;
 }
 
 void Anchor::StepBack() {
@@ -913,6 +922,13 @@ const double Anchor::GetMaxVelocity() const {
     return 0;
   }
 }
+
+//Returns whether anchor is walker or not
+bool Anchor::IsWalker () { 
+  bool walker = abs(GetMaxVelocity()) > input_tol ? true : false;
+  return walker;
+}
+
 
 const double Anchor::GetDiffusionConst() const {
   switch (state_) {

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -384,71 +384,109 @@ void Crosslink::CalculateTetherForces() {
   }
   anchors_[0].AddForce(force_);
   anchors_[1].SubForce(force_);
+  if (anchors_[0].IsWalker() == false) {
+    anchors_[0].SetCrosslinkLength(length_);
+  }
+  if (anchors_[1].IsWalker() == false) {
+    anchors_[1].SetCrosslinkLength(length_);
+  }
 
+  
   //If anchors are double bound and hopping between receptors then we need to calculate 
   //the energy to the neighboring sites to determine hopping rates
   if ((anchors_[0].IsBoundToSphere() == true) && (anchors_[1].IsBoundToSphere() == true)) {
     Sphere* sphere_zero_ = anchors_[0].GetBoundPointer();
     Sphere* sphere_one_ = anchors_[1].GetBoundPointer();
-
-    //receptor in plus direction of anchor zero
-    Sphere* zero_plus_n_ = sphere_zero_ -> GetPlusNeighbor();
-    Sphere* one_plus_n_ = sphere_one_ -> GetPlusNeighbor();
-    Sphere* zero_minus_n_ = sphere_zero_ -> GetMinusNeighbor();
-    Sphere* one_minus_n_ = sphere_one_ -> GetMinusNeighbor();
-    //If anchor is at plus end of microtubule it won't have a plus neighbor
-    if (one_plus_n_ == nullptr) {
-      anchors_[0].SetDisToOtherPlus(-1);
-    }
-    else {
-      //Get length between anchor zero and plus neighbor of anchor one
-      Interaction ix_zp(sphere_zero_, one_plus_n_);
-      MinimumDistance mindist_zp;
-      mindist_zp.ObjectObject(ix_zp);
-      double length_zp_ = sqrt(ix_zp.dr_mag2);
-      anchors_[0].SetDisToOtherPlus(length_zp_);  
-    }
-
-    //If anchor is at minus end of microtubule it won't have a plus neighbor
-    if (one_minus_n_ == nullptr) {
-      anchors_[0].SetDisToOtherMinus(-1);
-    }
-    else { 
-    //Get length between anchor zero and minus neighbor of anchor one
-      Interaction ix_zm(sphere_zero_, one_minus_n_);
-      MinimumDistance mindist_zm;
-      mindist_zm.ObjectObject(ix_zm);
-      double length_zm_ = sqrt(ix.dr_mag2);
-      anchors_[0].SetDisToOtherMinus(length_zm_);
-    }
-
-    //If anchor is at plus end of microtubule it won't have a plus neighbor
-    if (zero_plus_n_ == nullptr) {
-      anchors_[1].SetDisToOtherPlus(-1);
-    }
-    else { 
-    //Get length between anchor one and plus neighbor of anchor zero
-      Interaction ix_op(sphere_one_, zero_plus_n_);
-      MinimumDistance mindist_op;
-      mindist_op.ObjectObject(ix_op);
-      double length_op_ = sqrt(ix.dr_mag2);
-      anchors_[1].SetDisToOtherMinus(length_op_);
-    }
  
-    //If anchor is at plus end of microtubule it won't have a plus neighbor
-    if (zero_minus_n_ == nullptr) {
-      anchors_[1].SetDisToOtherMinus(-1);
+    Interaction ix_zo(sphere_zero_, sphere_one_);
+    MinimumDistance mindist_zo;
+    mindist_zo.ObjectObject(ix_zo);
+    double length_zo_ = sqrt(ix_zo.dr_mag2);
+
+
+    if (anchors_[0].IsWalker() == false) {
+      anchors_[0].SetCrosslinkLength(length_zo_);
     }
-    else { 
-      //Get length between anchor one and minus neighbor of anchor zero
-      Interaction ix_om(sphere_one_, zero_minus_n_);
-      MinimumDistance mindist_om;
-      mindist_om.ObjectObject(ix_om);
-      double length_om_ = sqrt(ix.dr_mag2); 
-      anchors_[1].SetDisToOtherMinus(-1);
+    if (anchors_[1].IsWalker() == false) {
+      anchors_[1].SetCrosslinkLength(length_zo_);
+    }
+    
+    if(anchors_[1].IsWalker() == false) {
+     //receptor in plus direction of anchor zero
+      Sphere* one_plus_n_ = sphere_one_ -> GetPlusNeighbor();
+      Sphere* one_minus_n_ = sphere_one_ -> GetMinusNeighbor();
+
+      //If anchor is at plus end of microtubule it won't have a plus neighbor
+      if (one_plus_n_ == nullptr) {
+        anchors_[1].SetDisToOtherPlus(-1);
+      }
+      else {
+        //Get length between anchor zero and plus neighbor of anchor one
+        Interaction ix_zp(sphere_zero_, one_plus_n_);
+        MinimumDistance mindist_zp;
+        mindist_zp.ObjectObject(ix_zp);
+        double length_zp_ = sqrt(ix_zp.dr_mag2);
+        anchors_[1].SetDisToOtherPlus(length_zp_);  
+      }
+
+      //If anchor is at minus end of microtubule it won't have a plus neighbor
+      if (one_minus_n_ == nullptr) {
+        anchors_[1].SetDisToOtherMinus(-1);
+     }
+      else { 
+        //Get length between anchor zero and minus neighbor of anchor one
+        Interaction ix_zm(sphere_zero_, one_minus_n_);
+        MinimumDistance mindist_zm;
+        mindist_zm.ObjectObject(ix_zm);
+        double length_zm_ = sqrt(ix_zm.dr_mag2);
+        anchors_[1].SetDisToOtherMinus(length_zm_);
+      }
+    }
+   if (anchors_[0].IsWalker() == false) {
+     Sphere* zero_plus_n_ = sphere_zero_ -> GetPlusNeighbor();
+      Sphere* zero_minus_n_ = sphere_zero_ -> GetMinusNeighbor();
+
+      //If anchor is at plus end of microtubule it won't have a plus neighbor
+      if (zero_plus_n_ == nullptr) {
+        anchors_[0].SetDisToOtherPlus(-1);
+     }
+
+      else { 
+
+      //Get length between anchor one and plus neighbor of anchor zero
+        Interaction ix_op(sphere_one_, zero_plus_n_);
+        double const *const loc_o = zero_plus_n_ -> GetPosition();
+
+        double const *const loc_t = sphere_zero_ -> GetPosition();
+        Logger::Warning("zero, %f, zero forward, %f", loc_t[0], loc_o[0]);
+        MinimumDistance mindist_op;
+
+        mindist_op.ObjectObject(ix_op);
+
+        double length_op_ = sqrt(ix_op.dr_mag2); 
+        anchors_[0].SetDisToOtherPlus(length_op_);
+      }
+
+      //If anchor is at plus end of microtubule it won't have a plus neighbor
+      if (zero_minus_n_ == nullptr) {
+        anchors_[0].SetDisToOtherMinus(-1);
+      }
+ 
+      else {  
+
+        double const *const loc_o = zero_minus_n_ -> GetPosition();
+
+        double const *const loc_t = sphere_one_ -> GetPosition();
+        Logger::Warning("one, %f, zero minus, %f", loc_t[0], loc_o[0]);
+       //Get length between anchor one and minus neighbor of anchor zero
+        Interaction ix_om(sphere_one_, zero_minus_n_);
+        MinimumDistance mindist_om;
+        mindist_om.ObjectObject(ix_om);
+        double length_om_ = sqrt(ix_om.dr_mag2); 
+        anchors_[0].SetDisToOtherMinus(length_om_);
+      }
     }
   }
-
   // If one anchor induces catastrophe and the other is attached to a filament, depolymerize
   // attached filament.
   if (anchors_[0].InducesCatastrophe() && anchors_[1].AttachedToFilamentLastBond()) {

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -384,26 +384,18 @@ void Crosslink::CalculateTetherForces() {
   }
   anchors_[0].AddForce(force_);
   anchors_[1].SubForce(force_);
-  if (anchors_[0].IsWalker() == false) {
-    anchors_[0].SetCrosslinkLength(length_);
-  }
-  if (anchors_[1].IsWalker() == false) {
-    anchors_[1].SetCrosslinkLength(length_);
-  }
 
-  
   //If anchors are double bound and hopping between receptors then we need to calculate 
   //the energy to the neighboring sites to determine hopping rates
   if ((anchors_[0].IsBoundToSphere() == true) && (anchors_[1].IsBoundToSphere() == true)) {
     Sphere* sphere_zero_ = anchors_[0].GetBoundPointer();
     Sphere* sphere_one_ = anchors_[1].GetBoundPointer();
  
+    //Calculate current length of crosslinker
     Interaction ix_zo(sphere_zero_, sphere_one_);
     MinimumDistance mindist_zo;
     mindist_zo.ObjectObject(ix_zo);
     double length_zo_ = sqrt(ix_zo.dr_mag2);
-
-
     if (anchors_[0].IsWalker() == false) {
       anchors_[0].SetCrosslinkLength(length_zo_);
     }
@@ -412,13 +404,13 @@ void Crosslink::CalculateTetherForces() {
     }
     
     if(anchors_[1].IsWalker() == false) {
-     //receptor in plus direction of anchor zero
+      //receptor in plus direction of anchor zero
       Sphere* one_plus_n_ = sphere_one_ -> GetPlusNeighbor();
       Sphere* one_minus_n_ = sphere_one_ -> GetMinusNeighbor();
 
       //If anchor is at plus end of microtubule it won't have a plus neighbor
       if (one_plus_n_ == nullptr) {
-        anchors_[1].SetDisToOtherPlus(-1);
+        anchors_[1].SetLengthAtPlus(-1);
       }
       else {
         //Get length between anchor zero and plus neighbor of anchor one
@@ -426,64 +418,52 @@ void Crosslink::CalculateTetherForces() {
         MinimumDistance mindist_zp;
         mindist_zp.ObjectObject(ix_zp);
         double length_zp_ = sqrt(ix_zp.dr_mag2);
-        anchors_[1].SetDisToOtherPlus(length_zp_);  
+        anchors_[1].SetLengthAtPlus(length_zp_);  
       }
 
       //If anchor is at minus end of microtubule it won't have a plus neighbor
       if (one_minus_n_ == nullptr) {
-        anchors_[1].SetDisToOtherMinus(-1);
-     }
+        anchors_[1].SetLengthAtMinus(-1);
+      }
       else { 
         //Get length between anchor zero and minus neighbor of anchor one
         Interaction ix_zm(sphere_zero_, one_minus_n_);
         MinimumDistance mindist_zm;
         mindist_zm.ObjectObject(ix_zm);
         double length_zm_ = sqrt(ix_zm.dr_mag2);
-        anchors_[1].SetDisToOtherMinus(length_zm_);
+        anchors_[1].SetLengthAtMinus(length_zm_);
       }
-    }
+   }
+
    if (anchors_[0].IsWalker() == false) {
      Sphere* zero_plus_n_ = sphere_zero_ -> GetPlusNeighbor();
-      Sphere* zero_minus_n_ = sphere_zero_ -> GetMinusNeighbor();
+     Sphere* zero_minus_n_ = sphere_zero_ -> GetMinusNeighbor();
 
-      //If anchor is at plus end of microtubule it won't have a plus neighbor
-      if (zero_plus_n_ == nullptr) {
-        anchors_[0].SetDisToOtherPlus(-1);
+     //If anchor is at plus end of microtubule it won't have a plus neighbor
+     if (zero_plus_n_ == nullptr) {
+       anchors_[0].SetLengthAtPlus(-1);
      }
 
-      else { 
+     else { 
 
-      //Get length between anchor one and plus neighbor of anchor zero
-        Interaction ix_op(sphere_one_, zero_plus_n_);
-        double const *const loc_o = zero_plus_n_ -> GetPosition();
-
-        double const *const loc_t = sphere_zero_ -> GetPosition();
-        Logger::Warning("zero, %f, zero forward, %f", loc_t[0], loc_o[0]);
-        MinimumDistance mindist_op;
-
-        mindist_op.ObjectObject(ix_op);
-
-        double length_op_ = sqrt(ix_op.dr_mag2); 
-        anchors_[0].SetDisToOtherPlus(length_op_);
+       //Get length between anchor one and plus neighbor of anchor zero
+       Interaction ix_op(sphere_one_, zero_plus_n_);
+       MinimumDistance mindist_op;
+       mindist_op.ObjectObject(ix_op);
+       double length_op_ = sqrt(ix_op.dr_mag2); 
+       anchors_[0].SetLengthAtPlus(length_op_);
       }
-
       //If anchor is at plus end of microtubule it won't have a plus neighbor
       if (zero_minus_n_ == nullptr) {
-        anchors_[0].SetDisToOtherMinus(-1);
+        anchors_[0].SetLengthAtMinus(-1);
       }
- 
       else {  
-
-        double const *const loc_o = zero_minus_n_ -> GetPosition();
-
-        double const *const loc_t = sphere_one_ -> GetPosition();
-        Logger::Warning("one, %f, zero minus, %f", loc_t[0], loc_o[0]);
-       //Get length between anchor one and minus neighbor of anchor zero
+        //Get length between anchor one and minus neighbor of anchor zero
         Interaction ix_om(sphere_one_, zero_minus_n_);
         MinimumDistance mindist_om;
         mindist_om.ObjectObject(ix_om);
         double length_om_ = sqrt(ix_om.dr_mag2); 
-        anchors_[0].SetDisToOtherMinus(length_om_);
+        anchors_[0].SetLengthAtMinus(length_om_);
       }
     }
   }

--- a/src/receptor_species.cpp
+++ b/src/receptor_species.cpp
@@ -109,6 +109,13 @@ void ReceptorSpecies::ArrangeMembers() {
 //Each receptor has it's neighbors set, this way diffusing/walking
 //motors know which receptor to move to
 void ReceptorSpecies::SetAllNeighbors() {
+
+  //Special case where filament has one receptor
+  //if (members_.size() == 1) {
+  //  members_[0].SetNeighbors(nullptr, nullptr);
+  //  return;
+  //}
+
   int i=0;
   //Cycle through each receptor
   while(i != members_.size()) {

--- a/src/receptor_species.cpp
+++ b/src/receptor_species.cpp
@@ -111,10 +111,10 @@ void ReceptorSpecies::ArrangeMembers() {
 void ReceptorSpecies::SetAllNeighbors() {
 
   //Special case where filament has one receptor
-  //if (members_.size() == 1) {
-  //  members_[0].SetNeighbors(nullptr, nullptr);
-  //  return;
-  //}
+  if (members_.size() == 1) {
+    members_[0].SetNeighbors(nullptr, nullptr);
+    return;
+  }
 
   int i=0;
   //Cycle through each receptor


### PR DESCRIPTION
## Description of changes
Fixed errors in crosslinker diffusion (was using wrong length when calculating diffusion, neighbors were set incorrectly when there was a single receptor, and single = in if statement). Also reorganized and renamed.

## Changes in behavior
Crosslinkers now diffuse properly.