### PR TITLE
Added flags to turn of binding

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -307,8 +307,11 @@ crosslink:                          # Parameters specific to crosslinks.
                                     # boundaries.
   begin_with_bound_crosslinks: [0, int]   # if greater than 0 the simultion begins with the specified number
                                     # of crosslinkers singly attached to microtubules
-  begin_double_bound: [true, bool]  # Crosslinks from begin with_with_bound_crosslinks start double 
+  begin_double_bound: [false, bool]  # Crosslinks from begin with_with_bound_crosslinks start double
                                     # bound. Only programmed for two parallel filaments. 
+  no_binding: [false, bool]         # With flag set to true crosslinks wont bind or unbind
+  no_solution_binding: [false, bool] # With flag set to true croeelinks will switch bewtween singly and double
+                                    # states but wont bind from solution or return to solution
   use_binding_volume: [true, bool]  # Calculate concentration of unbound head of 
                                     # singly bound protein by finding a binding 
                                     # volume in which it is statistically likely

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -141,7 +141,9 @@
   default_config["crosslink"]["anchors"][1]["k_off_d"] = "2";
   default_config["crosslink"]["concentration"] = "0";
   default_config["crosslink"]["begin_with_bound_crosslinks"] = "0";
-  default_config["crosslink"]["begin_double_bound"] = "true";
+  default_config["crosslink"]["begin_double_bound"] = "false";
+  default_config["crosslink"]["no_binding"] = "false";
+  default_config["crosslink"]["no_solution_binding"] = "false";
   default_config["crosslink"]["use_binding_volume"] = "true";
   default_config["crosslink"]["infinite_reservoir_flag"] = "false";
   default_config["crosslink"]["bind_site_density"] = "1";

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -164,7 +164,9 @@ struct species_parameters<species_id::crosslink>
     : public species_base_parameters {
   double concentration = 0;
   int begin_with_bound_crosslinks = 0;
-  bool begin_double_bound = true;
+  bool begin_double_bound = false;
+  bool no_binding = false;
+  bool no_solution_binding = false;
   bool use_binding_volume = true;
   bool infinite_reservoir_flag = false;
   double bind_site_density = 1;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -679,6 +679,10 @@ species_base_parameters *parse_species_params(std::string sid,
       params.begin_with_bound_crosslinks = jt->second.as<int>();
       } else if (param_name.compare("begin_double_bound")==0) {
       params.begin_double_bound = jt->second.as<bool>();
+      } else if (param_name.compare("no_binding")==0) {
+      params.no_binding = jt->second.as<bool>();
+      } else if (param_name.compare("no_solution_binding")==0) {
+      params.no_solution_binding = jt->second.as<bool>();
       } else if (param_name.compare("use_binding_volume")==0) {
       params.use_binding_volume = jt->second.as<bool>();
       } else if (param_name.compare("infinite_reservoir_flag")==0) {

--- a/src/crosslink.cpp
+++ b/src/crosslink.cpp
@@ -68,7 +68,7 @@ void Crosslink::SinglyKMC() {
   int head_bound = 0;
   // Set up KMC objects and calculate probabilities
   double unbind_prob = anchors_[bound_anchor_].GetOffRate() * delta_;
-  if (static_flag_) {
+  if (static_flag_ || sparams_->no_solution_binding) {
     unbind_prob = 0;
   }
   tracker_->TrackSU(unbind_prob);
@@ -333,8 +333,10 @@ void Crosslink::UpdateCrosslinkPositions() {
   UpdateAnchorPositions();
   /* Check if an anchor became unbound do to diffusion, etc */
   UpdateXlinkState();
-  /* Check for binding/unbinding events using KMC */
-  CalculateBinding();
+  if (sparams_->no_binding == false){
+    /* Check for binding/unbinding events using KMC */
+    CalculateBinding();
+  }
 }
 
 /* This function ensures that singly-bound crosslinks have anchor[0] bound and

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -453,8 +453,10 @@ void CrosslinkSpecies::UpdatePositions() {
   if (!params_->on_midstep) {
     /* First update bound crosslinks state and positions */
     UpdateBoundCrosslinks();
-    /* Calculate implicit binding of crosslinks from solution */
-    CalculateBindingFree();
+    if (sparams_.no_binding == false && sparams_.no_solution_binding == false){
+      /* Calculate implicit binding of crosslinks from solution */
+      CalculateBindingFree();
+    }
   } else {
     /* Apply tether forces from doubly-bound crosslinks onto anchored objects.
        We do this every half step only, because the fullstep tether forces are


### PR DESCRIPTION
## Description of changes
Added no_binding flag which makes so crosslinks don't bind or unbind. Also added no_solution_binding flag which makes so crosslinkers will bind between single and double states, but not between solution and singly states.
