### PR TITLE
Add ability to set different diffusion constants for different heads

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -367,6 +367,12 @@ crosslink:                          # Parameters specific to crosslinks.
   anchors:
     velocity_s: [0, double]           # Bound crosslink head velocities when walkers are singly bound.
     velocity_d: [0, double]           # Bound crosslink head velocities when walkers are doubly bound.
+    diffusion_s: [-1, double]         # Diffusion coefficient for singly bound crosslinks, use to give
+                                      # heads separate diffusion constants.
+                                      # If not changed from -1 crosslinker diffusion parameter is used instead.
+    diffusion_d: [-1, double]         # Diffusion coefficient for doubly bound crosslinks, use to give
+                                      # heads separate diffusion constants.
+                                      # If not changed from -1 crosslinker diffusion parameter is used instead.
     color: [0, double]                # Anchor color
     bind_file: [none, string]         # File of species crosslink can bind to, and binding rates. If none, bind to
     use_partner: [false, bool]        # Load/unload partner protein- determines dynamic instability

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -121,6 +121,10 @@
   default_config["crosslink"]["anchors"][1]["velocity_s"] = "0";
   default_config["crosslink"]["anchors"][0]["velocity_d"] = "0";
   default_config["crosslink"]["anchors"][1]["velocity_d"] = "0";
+  default_config["crosslink"]["anchors"][0]["diffusion_s"] = "-1";
+  default_config["crosslink"]["anchors"][1]["diffusion_s"] = "-1";
+  default_config["crosslink"]["anchors"][0]["diffusion_d"] = "-1";
+  default_config["crosslink"]["anchors"][1]["diffusion_d"] = "-1";
   default_config["crosslink"]["anchors"][0]["color"] = "0";
   default_config["crosslink"]["anchors"][1]["color"] = "0";
   default_config["crosslink"]["anchors"][0]["bind_file"] = "none";

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -199,6 +199,8 @@ struct species_parameters<species_id::crosslink>
   struct anchor_parameters {
     double velocity_s = 0;
     double velocity_d = 0;
+    double diffusion_s = -1;
+    double diffusion_d = -1;
     double color = 0;
     std::string bind_file = "none";
     bool use_partner = false;

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -762,6 +762,16 @@ species_base_parameters *parse_species_params(std::string sid,
               if (jt->second.size() < 2 || !jt->second[(int)!i]["velocity_d"]) {
                  params.anchors[(int)!i].velocity_d = params.anchors[i].velocity_d;
               }
+            } else if (sub_param_name.compare("diffusion_s")==0) {
+              params.anchors[i].diffusion_s = kt->second.as<double>();
+              if (jt->second.size() < 2 || !jt->second[(int)!i]["diffusion_s"]) {
+                 params.anchors[(int)!i].diffusion_s = params.anchors[i].diffusion_s;
+              }
+            } else if (sub_param_name.compare("diffusion_d")==0) {
+              params.anchors[i].diffusion_d = kt->second.as<double>();
+              if (jt->second.size() < 2 || !jt->second[(int)!i]["diffusion_d"]) {
+                 params.anchors[(int)!i].diffusion_d = params.anchors[i].diffusion_d;
+              }
             } else if (sub_param_name.compare("color")==0) {
               params.anchors[i].color = kt->second.as<double>();
               if (jt->second.size() < 2 || !jt->second[(int)!i]["color"]) {

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -17,8 +17,18 @@ void Anchor::Init(crosslink_parameters *sparams, int index) {
       (sparams_->step_direction == 0 ? 0 : SIGNOF(sparams_->step_direction));
   max_velocity_s_ = sparams->anchors[index_].velocity_s;
   max_velocity_d_ = sparams->anchors[index_].velocity_d;
-  diffusion_s_ = sparams->diffusion_s;
-  diffusion_d_ = sparams->diffusion_d;
+  //If anchor parameters are not set and at their default values use the crosslinker diffusion.
+  //If anchor parameters are set use the anchor parameters. 
+  if (sparams_->anchors[index_].diffusion_s == -1) {
+    diffusion_s_ = sparams->diffusion_s;
+  } else {
+    diffusion_s_ = sparams_->anchors[index_].diffusion_s;
+  }
+  if (sparams_->anchors[index_].diffusion_d == -1) {
+    diffusion_d_ = sparams->diffusion_d;
+  } else {
+    diffusion_d_ = sparams_->anchors[index_].diffusion_d;
+  }
   use_partner_ = sparams_->anchors[index_].use_partner;
   k_on_s_ = sparams_->anchors[index_].k_on_s;
   partner_on_s_ = sparams_->anchors[index_].partner_on_s;

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -12,7 +12,7 @@ void CrosslinkSpecies::Init(std::string spec_name, ParamsParser &parser) {
   begin_with_bound_crosslinks_ = sparams_.begin_with_bound_crosslinks;
   xlink_concentration_ = sparams_.concentration;
   infinite_reservoir_flag_ = sparams_.infinite_reservoir_flag;
-  if (sparams_.use_number=false) {
+  if (sparams_.use_number==false) {
     sparams_.num = (int)round(sparams_.concentration * space_->volume);
   }
   std::vector<std::string> bind_file = {sparams_.anchors[0].bind_file, sparams_.anchors[1].bind_file};


### PR DESCRIPTION
## Description of changes
Add the ability to set individual diffusion constants for individual heads (anchors), if anchors diffusions are not changed from default crosslinker diffusion is still used.
