### PR TITLE
Added the protrusion boundary type

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -12,6 +12,8 @@ boundary : [0, int]                  # 0: No boundary condition constraints.
                                      # 1: Box-like boundary condition.
                                      # 2: Spherical BC with radius of system_radius.
                                      # 3: Budding-yeast BC with mother and daughter cell.
+                                     # 4: Wall like boundary condition
+                                     # 5: Protrusion type boundary condition
 system_radius : [100, double]        # Sets system volume. 1D system length is 2 x system_radius.
 n_steps : [1000000, int]             # Number of steps to run simulation before completion.
 i_step: [0, int]                     # Internal parameter used for tracking simulation iteration.
@@ -35,6 +37,10 @@ movie_directory : [frames, string]   # Directory to output graphics bitmaps
 time_analysis : [false, bool]        # Generate output file with simulation runtime data
 bud_height : [680, double]           # center separation of mother and daughter cells
 bud_radius : [300, double]           # radius of daughter cell
+protrusion_radius: [2, double]      # Radius of protrusion when using protrusion boundary type
+protrusion_length: [80, double]      # Final length of protrusion when using protrusion boundary type
+protrusion_growth_speed: [0, double] # Growth speed of protrsuion when using protrusion boundary type
+start_protrusion_growth: [0, double] # Time when protrusion starts growing when using protrusion growth type
 lj_epsilon: [1, double]              # Energy scaling factor for Lennard-Jones potential
 wca_eps: [1, double]                 # Energy scaling factor for WCA potential
 wca_sig: [1, double]                 # Distance scaling factor for WCA potential
@@ -75,6 +81,8 @@ static_particle_number: [false, bool] # Tells interaction engine that particle n
                                       # change, circumventing certain book-keeping functions.
 checkpoint_from_spec: [false, bool]  # Generate a checkpoint file from an existing spec file.
 potential: [wca, string]             # Specifies interaction potential between all particles.
+reflect_at_boundary: [false, bool]   # If true particles outside the set boundary are relfected back inside,
+                                     # only set up for sphere and protrusion boundaries
 soft_potential_mag: [10, double]     # Energy scaling parameter for GEM-8 potential.
 soft_potential_mag_target: [-1, double] # If >= 0, rescales GEM-8 energy to meet target in 
                                         # n_steps_target steps.
@@ -106,6 +114,7 @@ knockout_xlink: [false, bool]        # Use knockout algorithm to limit occupancy
 no_midstep: [false, bool]            # Specify the simulation is not using a mid step algorithm 
 single_occupancy: [true, bool]       # when set to false the sites can be occupied by multiple crosslinkers
                                      # not yet set up to be false with binding/unbinding on
+turn_off_cell_list: [false, bool]    # If set to true there will only be one cell.
 
 species:                             # Shared parameters used for all species.
   name: [species, string]            # Label given to species (e.g. microtubule, kinesin, etc)

--- a/include/cglass/cell_list.hpp
+++ b/include/cglass/cell_list.hpp
@@ -22,7 +22,7 @@ private:
 
 public:
   CellList() {}
-  static void Init(int n_dim, int n_periodic, double system_radius);
+  static void Init(int n_dim, int n_periodic, double system_radius, bool turn_off_cell_list);
   static void SetMinCellLength(double l);
   static double GetCellLength();
   void MakePairs(std::vector<Interaction> &pair_list);

--- a/include/cglass/crosslink.hpp
+++ b/include/cglass/crosslink.hpp
@@ -46,6 +46,7 @@ private:
   void FreeKMC();
   void SinglyKMC();
   void DoublyKMC();
+  void ReflectAtBoundary();
   void UpdateAnchorsToMesh();
   void UpdateAnchorPositions();
   void UpdateXlinkState();

--- a/include/cglass/default_params.hpp
+++ b/include/cglass/default_params.hpp
@@ -214,6 +214,10 @@
   default_config["time_analysis"] = "false";
   default_config["bud_height"] = "680";
   default_config["bud_radius"] = "300";
+  default_config["protrusion_radius"] = "2";
+  default_config["protrusion_length"] = "80";
+  default_config["protrusion_growth_speed"] = "0";
+  default_config["start_protrusion_growth"] = "0";
   default_config["lj_epsilon"] = "1";
   default_config["wca_eps"] = "1";
   default_config["wca_sig"] = "1";
@@ -243,6 +247,7 @@
   default_config["static_particle_number"] = "false";
   default_config["checkpoint_from_spec"] = "false";
   default_config["potential"] = "wca";
+  default_config["reflect_at_boundary"] = "false";
   default_config["soft_potential_mag"] = "10";
   default_config["soft_potential_mag_target"] = "-1";
   default_config["like_like_interactions"] = "true";
@@ -263,3 +268,4 @@
   default_config["knockout_xlink"] = "false";
   default_config["no_midstep"] = "false";
   default_config["single_occupancy"] = "true";
+  default_config["turn_off_cell_list"] = "false";

--- a/include/cglass/definitions.hpp
+++ b/include/cglass/definitions.hpp
@@ -19,7 +19,7 @@ BETTER_ENUM(species_id, unsigned char, br_bead, filament, rigid_filament,
 BETTER_ENUM(draw_type, unsigned char, fixed, orientation, bw, none);
 BETTER_ENUM(potential_type, unsigned char, none, wca, soft, lj);
 BETTER_ENUM(boundary_type, unsigned char, none = 0, box = 1, sphere = 2,
-            budding = 3, wall = 4);
+            budding = 3, wall = 4, protrusion = 5);
 BETTER_ENUM(poly_state, unsigned char, grow, shrink, pause);
 BETTER_ENUM(bind_state, unsigned char, unbound, singly, doubly, free);
 BETTER_ENUM(obj_type, unsigned char, generic, bond, site, cortex);

--- a/include/cglass/graphics.hpp
+++ b/include/cglass/graphics.hpp
@@ -127,6 +127,7 @@ class Graphics {
   void Draw2dBudding();  // Draws budding boundary
   void Draw3dBudding();  // Draws budding boundary
   void DrawSpheros();    // draw spherocylinders (3d)
+  void DrawWireCylinder(double center, double radius, double length); //Draw cylinder, used for protrusion boundary
   void
   DrawDiscorectangles();  // draw solid discorectangles (2d spherocylinders)
   void UpdateWindow();    // update window parameters in case of resize

--- a/include/cglass/minimum_distance.hpp
+++ b/include/cglass/minimum_distance.hpp
@@ -12,9 +12,11 @@ private:
   static double boundary_cut2_;
   static SpaceBase *space_;
   double new_radius_;
+  double new_x_value_;
 
 public:
   double GetNewRadius();
+  double GetNewXValue();
   void PointPoint(double const *const r1, double const *const s1,
                   double const *const r2, double const *const s2, double *dr,
                   double *dr_mag2, double *midpoint);

--- a/include/cglass/parameters.hpp
+++ b/include/cglass/parameters.hpp
@@ -260,6 +260,10 @@ struct system_parameters {
   bool time_analysis = false;
   double bud_height = 680;
   double bud_radius = 300;
+  double protrusion_radius = 2;
+  double protrusion_length = 80;
+  double protrusion_growth_speed = 0;
+  double start_protrusion_growth = 0;
   double lj_epsilon = 1;
   double wca_eps = 1;
   double wca_sig = 1;
@@ -289,6 +293,7 @@ struct system_parameters {
   bool static_particle_number = false;
   bool checkpoint_from_spec = false;
   std::string potential = "wca";
+  bool reflect_at_boundary = false;
   double soft_potential_mag = 10;
   double soft_potential_mag_target = -1;
   bool like_like_interactions = true;
@@ -309,6 +314,7 @@ struct system_parameters {
   bool knockout_xlink = false;
   bool no_midstep = false;
   bool single_occupancy = true;
+  bool turn_off_cell_list = false;
 };
 
 #endif // _CGLASS_PARAMETERS_H_

--- a/include/cglass/parse_params.hpp
+++ b/include/cglass/parse_params.hpp
@@ -70,6 +70,14 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.bud_height = it->second.as<double>();
     } else if (param_name.compare("bud_radius")==0) {
     params.bud_radius = it->second.as<double>();
+    } else if (param_name.compare("protrusion_radius")==0) {
+    params.protrusion_radius = it->second.as<double>();
+    } else if (param_name.compare("protrusion_length")==0) {
+    params.protrusion_length = it->second.as<double>();
+    } else if (param_name.compare("protrusion_growth_speed")==0) {
+    params.protrusion_growth_speed = it->second.as<double>();
+    } else if (param_name.compare("start_protrusion_growth")==0) {
+    params.start_protrusion_growth = it->second.as<double>();
     } else if (param_name.compare("lj_epsilon")==0) {
     params.lj_epsilon = it->second.as<double>();
     } else if (param_name.compare("wca_eps")==0) {
@@ -128,6 +136,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.checkpoint_from_spec = it->second.as<bool>();
     } else if (param_name.compare("potential")==0) {
     params.potential = it->second.as<std::string>();
+    } else if (param_name.compare("reflect_at_boundary")==0) {
+    params.reflect_at_boundary = it->second.as<bool>();
     } else if (param_name.compare("soft_potential_mag")==0) {
     params.soft_potential_mag = it->second.as<double>();
     } else if (param_name.compare("soft_potential_mag_target")==0) {
@@ -168,6 +178,8 @@ system_parameters parse_system_params(YAML::Node &node) {
     params.no_midstep = it->second.as<bool>();
     } else if (param_name.compare("single_occupancy")==0) {
     params.single_occupancy = it->second.as<bool>();
+    } else if (param_name.compare("turn_off_cell_list")==0) {
+    params.turn_off_cell_list = it->second.as<bool>();
     } else {
       Logger::Warning("Unrecognized parameter '%s'", param_name.c_str());
     }

--- a/include/cglass/space.hpp
+++ b/include/cglass/space.hpp
@@ -28,6 +28,11 @@ private:
   double neck_radius_ = 0; // radius of opening between mother-daughter cells
   double v_ratio_ = 0;     // percentage daughter cell volume to total volume
 
+  //protrusion_data
+  double pro_radius_ = 0;
+  double pro_length_ = 0;
+  double pro_start_ = 0;
+
   // statistical data
   bool constant_pressure_ = false;
   bool constant_volume_ = false;
@@ -60,6 +65,7 @@ public:
   void UpdateSpace();
   void ConstantPressure();
   void ConstantVolume();
+  void GrowProtrusion();
   SpaceBase *GetSpaceBase();
   bool GetUpdate() { return update_; }
 };

--- a/include/cglass/space_base.hpp
+++ b/include/cglass/space_base.hpp
@@ -18,6 +18,9 @@ public:
   double bud_height;
   double bud_neck_radius;
   double bud_neck_height;
+  double pro_radius; //protrusion radius
+  double pro_length; //protrusion length
+  double pro_start; //x coordinate where protrusion meets sphere
   double *unit_cell;
   double *unit_cell_inv;  // inverse unit cell
   double *a;              // direct lattice vector

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -593,7 +593,7 @@ void Anchor::Draw(std::vector<graph_struct *> &graph_array) {
   }
   std::copy(orientation_, orientation_ + 3, g_.u);
   g_.color = color_;
-  g_.diameter = diameter_;
+  g_.diameter = 2; //diameter_;
   g_.length = length_;
   g_.draw = draw_;
   graph_array.push_back(&g_);

--- a/src/cell_list.cpp
+++ b/src/cell_list.cpp
@@ -15,8 +15,12 @@ void CellList::SetMinCellLength(double l) {
 }
 double CellList::GetCellLength() { return _cell_length_; }
 
-void CellList::Init(int n_dim, int n_periodic, double system_radius) {
-  _n_cells_1d_ = (int)floor(2 * system_radius / _min_cell_length_);
+void CellList::Init(int n_dim, int n_periodic, double system_radius, bool turn_off_cell_list) {
+  if (turn_off_cell_list == true) {
+    _n_cells_1d_ = 1;
+  } else {
+    _n_cells_1d_ = (int)floor(2 * system_radius / _min_cell_length_);
+  }
   _no_init_ = false;
 #ifdef TRACE
   if (_n_cells_1d_ > 20) {

--- a/src/crosslink_species.cpp
+++ b/src/crosslink_species.cpp
@@ -224,9 +224,9 @@ void CrosslinkSpecies::InsertCrosslinks() {
     return;
   } else if (sparams_.insertion_type.compare("free") == 0) {
     Logger::Info("Inserting %i unbound crosslinks", sparams_.num);
-    if (space_->type != +boundary_type::sphere) {
-      Logger::Error("Tracking unbound crosslinkers not set up for current boundry type");
-    } else if (space_->type == +boundary_type::sphere) {
+if (space_->type != +boundary_type::sphere  && space_->type != +boundary_type::protrusion) {
+    Logger::Error("Tracking unbound crosslinkers not set up for current boundry type");
+    } else if (space_->type == +boundary_type::sphere || space_->type == +boundary_type::protrusion) {
       for (int i = 0; i < sparams_.num; ++i) {
         AddMember();
         members_.back().InsertRandom(); 
@@ -262,7 +262,7 @@ void CrosslinkSpecies::InsertCrosslinks() {
           space_->type == +boundary_type::box) {
         sparams_.num = (int)round(4 * space_->radius * space_->radius *
                                   xlink_concentration_);
-      } else if (space_->type == +boundary_type::sphere) {
+      } else if (space_->type == +boundary_type::sphere || space_->type == +boundary_type::protrusion) {
         sparams_.num = (int)round(M_PI * space_->radius * space_->radius *
                                   xlink_concentration_);
       } else if (space_->type == +boundary_type::budding) {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -782,6 +782,17 @@ void Graphics::DrawBoundary() {
     DrawBox();
   else if (boundary_ == +boundary_type::budding)
     DrawBudding();
+  else if (boundary_ == +boundary_type::protrusion) {
+    glDisable(GL_LIGHTING);
+    glDisable(GL_CULL_FACE);
+    if (n_dim_ == 2){
+      Logger::Error("Protrusion not set up for 2d");
+    }
+    if (n_dim_ == 3){
+      DrawWireSphere(0.5 * unit_cell_[0], 16, 16);
+      DrawWireCylinder(0.5 * unit_cell_[0], space_->pro_radius, space_->pro_length);
+    }
+  }
 }
 
 void Graphics::DrawWireSphere(double r, int lats, int longs) {
@@ -811,6 +822,33 @@ void Graphics::DrawWireSphere(double r, int lats, int longs) {
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
   glEnable(GL_LIGHTING);
   glEnable(GL_CULL_FACE);
+}
+
+void Graphics::DrawWireCylinder(double start, double r, double length) {
+  glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+  glLineWidth(1.0);
+  int spacing = 2;
+  int lats = length/spacing;
+  int longs = 8;
+  for (int i = 0; i <= lats; i++) {
+    double lat0 = ((double)(-i*spacing));
+    double z0 = lat0;
+    double zr0 = 1;
+    double lat1 = ((double)(-i/3));
+    double z1 = r * lat1;
+    double zr1 = 1;
+    glBegin(GL_QUAD_STRIP);
+    for (int j = 0; j <= longs; j++) {
+      double lng = 2 * M_PI * (double)(j - 1) / longs;
+      double x = r * cos(lng);
+      double y = r * sin(lng);
+      glNormal3f(z0-start, y * zr0, x * zr0);
+      glVertex3f(z0-start, y * zr0, x * zr0);
+      glNormal3f(z1-start, y * zr1, x * zr1);
+      glVertex3f(z1-start, y * zr1, x * zr1);
+    }
+    glEnd();
+  }
 }
 
 void Graphics::DrawLoop() {

--- a/src/interaction_manager.cpp
+++ b/src/interaction_manager.cpp
@@ -39,7 +39,7 @@ void InteractionManager::InitInteractions() {
   potentials_.InitPotentials(params_);
   CellList::SetMinCellLength(sqrt(potentials_.GetRCut2()));
 
-  CellList::Init(params_->n_dim, params_->n_periodic, params_->system_radius);
+  CellList::Init(params_->n_dim, params_->n_periodic, params_->system_radius, params_->turn_off_cell_list);
   Logger::Info("Constructing cell list data structure");
   clist_.BuildCellList();
 

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -79,6 +79,13 @@ void RNG::RandomCoordinate(const SpaceBase *const s, double *vec,
         vec[i] *= mag;
       }
       break;
+    case +boundary_type::protrusion:  // protrusion boundry has crosslinkers inserted into sphereical section
+      RandomUnitVector(n_dim, vec);
+      mag = pow( gsl_rng_uniform_pos(rng_), .3333333 ) * (R - buffer);
+      for (int i = 0; i < n_dim; ++i) {
+        vec[i] *= mag;
+      }
+      break;
     // budding yeast boundary type
     case +boundary_type::budding:  // budding
     {
@@ -144,6 +151,13 @@ void RNG::RandomBoundaryCoordinate(const SpaceBase *const s, double *vec) {
       break;
     }
     case boundary_type::sphere: {
+      RandomUnitVector(n_dim, vec);
+      for (int i = 0; i < n_dim; ++i) {
+        vec[i] *= R;
+      }
+      break;
+    }
+    case boundary_type::protrusion: {
       RandomUnitVector(n_dim, vec);
       for (int i = 0; i < n_dim; ++i) {
         vec[i] *= R;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -136,6 +136,10 @@ void Simulation::Integrate() {
   for (auto it = species_.begin(); it != species_.end(); ++it) {
     (*it)->UpdatePositions();
   }
+  //If using protrusion boundry, and protrusion has started growth
+  if (params_.boundary == 5 && time_ > params_.start_protrusion_growth) {
+    space_.GrowProtrusion();
+  }
 }
 
 /* Calculate interaction forces between all objects if necessary. */

--- a/src/space_base.cpp
+++ b/src/space_base.cpp
@@ -13,6 +13,17 @@ double SpaceBase::BoundaryArea() const{
         return 4 * M_PI * SQR(radius);
       }
     } 
+    //Protrusion currently set to have same area of sphere
+    //for simulations with protrusions this is only used to
+    //decide object number from concentration
+    case +boundary_type::protrusion: {
+      Logger::Info("Passing through for protrusion");
+      if (n_dim == 2) {
+        return 2.0 * M_PI * radius;
+      } else {
+        return 4 * M_PI * SQR(radius);
+      }
+    }
     case +boundary_type::box: {
       if (n_dim == 2) {
         return 8.0 * radius;


### PR DESCRIPTION
Added the protrusion boundary type to C-GLASS. In this boundary type there is a cylinder connected to a sphere made to resemble protrusions in S. pombe cells. The cylinder can be static or grow. The protrusion boundary type is currently only set up to directly reflect objects at the boundary edges. It is not set up to have a force at the boundary like the other boundary types.
